### PR TITLE
[FE] 로그인 상태 관리 추가, 로그인 상태에 따른 UI 및 동작 변경 구현

### DIFF
--- a/frontend/tiggle/package-lock.json
+++ b/frontend/tiggle/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^4.29.23",
         "@tanstack/react-query-devtools": "^4.29.23",
         "@types/antd": "^1.0.0",
+        "@types/redux-persist": "^4.3.1",
         "antd": "^5.11.1",
         "classnames": "^2.3.2",
         "dayjs": "^1.11.9",
@@ -25,6 +26,7 @@
         "react-masonry-css": "^1.0.16",
         "react-redux": "^8.1.1",
         "react-router-dom": "^6.14.2",
+        "redux-persist": "^6.0.0",
         "styled-components": "^6.0.5",
         "token-transformer": "^0.0.33"
       },
@@ -7040,6 +7042,15 @@
       "devOptional": true,
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/redux-persist": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/redux-persist/-/redux-persist-4.3.1.tgz",
+      "integrity": "sha512-YkMnMUk+4//wPtiSTMfsxST/F9Gh9sPWX0LVxHuOidGjojHtMdpep2cYvQgfiDMnj34orXyZI+QJCQMZDlafKA==",
+      "deprecated": "This is a stub types definition for redux-persist (https://github.com/rt2zz/redux-persist). redux-persist provides its own type definitions, so you don't need @types/redux-persist installed!",
+      "dependencies": {
+        "redux-persist": "*"
       }
     },
     "node_modules/@types/retry": {
@@ -19800,6 +19811,14 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.2.tgz",
@@ -27575,6 +27594,14 @@
       "devOptional": true,
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@types/redux-persist": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/redux-persist/-/redux-persist-4.3.1.tgz",
+      "integrity": "sha512-YkMnMUk+4//wPtiSTMfsxST/F9Gh9sPWX0LVxHuOidGjojHtMdpep2cYvQgfiDMnj34orXyZI+QJCQMZDlafKA==",
+      "requires": {
+        "redux-persist": "*"
       }
     },
     "@types/retry": {
@@ -36799,6 +36826,12 @@
       "requires": {
         "@babel/runtime": "^7.9.2"
       }
+    },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
     },
     "redux-thunk": {
       "version": "2.4.2",

--- a/frontend/tiggle/package.json
+++ b/frontend/tiggle/package.json
@@ -20,6 +20,7 @@
     "@tanstack/react-query": "^4.29.23",
     "@tanstack/react-query-devtools": "^4.29.23",
     "@types/antd": "^1.0.0",
+    "@types/redux-persist": "^4.3.1",
     "antd": "^5.11.1",
     "classnames": "^2.3.2",
     "dayjs": "^1.11.9",
@@ -32,6 +33,7 @@
     "react-masonry-css": "^1.0.16",
     "react-redux": "^8.1.1",
     "react-router-dom": "^6.14.2",
+    "redux-persist": "^6.0.0",
     "styled-components": "^6.0.5",
     "token-transformer": "^0.0.33"
   },

--- a/frontend/tiggle/src/Router.tsx
+++ b/frontend/tiggle/src/Router.tsx
@@ -9,11 +9,11 @@ import CreatePage, {
 } from "@/pages/CreatePage";
 import DetailPage, { loader as detailPageLoader } from "@/pages/DetailPage";
 import LoginPage from "@/pages/LoginPage";
+import LoginRedirectPage from "@/pages/LoginRedirectPage";
 import MainPage from "@/pages/MainPage";
+import NotFoundPage from "@/pages/NotFoundPage";
 import queryClient from "@/query/queryClient";
 import GeneralTemplate from "@/templates/GeneralTemplate";
-
-import NotFoundPage from "./pages/NotFoundPage";
 
 export default createBrowserRouter(
   createRoutesFromElements(
@@ -44,6 +44,7 @@ export default createBrowserRouter(
         <Route path="/" element={<MainPage />} />
       </Route>
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/login/success" element={<LoginRedirectPage />} />
       <Route path="*" element={<NotFoundPage />} />
     </>,
   ),

--- a/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.stories.tsx
+++ b/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.stories.tsx
@@ -16,5 +16,6 @@ export const Default: Story = {
     size: "md",
     children: "기록하기",
     icon: <Edit3 />,
+    disabled: false,
   },
 };

--- a/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.tsx
+++ b/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.tsx
@@ -11,7 +11,7 @@ export const CTAButtonColors = [
   "bluishGray",
 ] as const;
 interface CTAButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  size?: "md" | "lg";
+  size?: "sm" | "md" | "lg";
   icon?: ReactElement;
   fullWidth?: boolean;
   variant?: "primary" | "secondary" | "light";

--- a/frontend/tiggle/src/components/molecules/CommentCell/CommentCell.tsx
+++ b/frontend/tiggle/src/components/molecules/CommentCell/CommentCell.tsx
@@ -3,6 +3,7 @@ import { SubmitHandler, useForm, Controller } from "react-hook-form";
 import { useSelector } from "react-redux";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { Avatar } from "antd";
 
 import CTAButton from "@/components/atoms/CTAButton/CTAButton";
 import ReplyToggleButton from "@/components/atoms/ReplyToggleButton/ReplyToggleButton";
@@ -79,9 +80,9 @@ export default function CommentCell({
   return (
     <CommentCellStyle>
       <CommentSenderStyle>
-        <img
-          className="profile"
-          src={sender.profileUrl ?? "/assets/user-placeholder.png"}
+        <Avatar
+          size={32}
+          src={sender.profileUrl}
           alt={`${sender.nickname} profile`}
         />
         <div>

--- a/frontend/tiggle/src/components/molecules/CommentForm/CommentForm.tsx
+++ b/frontend/tiggle/src/components/molecules/CommentForm/CommentForm.tsx
@@ -3,10 +3,11 @@ import { SubmitHandler, useForm, Controller } from "react-hook-form";
 import { useSelector } from "react-redux";
 
 import { useMutation } from "@tanstack/react-query";
-import { message } from "antd";
+import { Avatar, message } from "antd";
 
 import CTAButton from "@/components/atoms/CTAButton/CTAButton";
 import { CommentApiService } from "@/generated";
+import useLogin from "@/hooks/useLogin";
 import queryClient from "@/query/queryClient";
 import { RootState } from "@/store";
 import { CommentSenderStyle } from "@/styles/components/CommentCellStyle";
@@ -29,15 +30,20 @@ export default function CommentForm({
   receiverId,
   ...props
 }: CommentFormProps) {
+  const { isLogin, profile, checkIsLogin } = useLogin();
   const txType = useSelector((state: RootState) => state.detailPage.txType);
-
   const [messageApi, contextHolder] = message.useMessage();
-  const { control, handleSubmit, reset } = useForm<CommentFormInputs>();
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { isValid },
+  } = useForm<CommentFormInputs>();
 
   const { mutate: createComment } = useMutation(async (content: string) =>
     CommentApiService.createComment(TEMP_USER_ID, {
       txId,
-      senderId: TEMP_USER_ID,
+      senderId: profile.id,
       receiverId: receiverId,
       content,
     }),
@@ -45,8 +51,6 @@ export default function CommentForm({
 
   const onSubmit: SubmitHandler<CommentFormInputs> = ({ comment }, event) => {
     event.preventDefault();
-    if (comment === "") return;
-
     createComment(comment, {
       onSuccess: () => {
         messageApi.open({ type: "success", content: "댓글이 등록되었습니다." });
@@ -65,18 +69,29 @@ export default function CommentForm({
         className={txType}
       >
         <CommentSenderStyle>
-          <img className="profile" />
-          <p className="name">내 이름</p>
+          {isLogin && profile ? (
+            <>
+              <Avatar size={32} src={profile.profileUrl} />
+              <p className="name">{profile.nickname}</p>
+            </>
+          ) : (
+            <>
+              <Avatar size={32} />
+              <p className="name">사용자</p>
+            </>
+          )}
         </CommentSenderStyle>
 
         <Controller
           name="comment"
           control={control}
+          rules={{ required: true }}
           render={({ field }) => (
             <textarea
               className="comment"
               placeholder="댓글 남기기"
               rows={2}
+              onFocus={() => checkIsLogin()}
               {...field}
             />
           )}
@@ -88,6 +103,7 @@ export default function CommentForm({
             variant="secondary"
             color={convertTxTypeToColor(txType)}
             type="submit"
+            disabled={!isValid}
           >
             댓글 등록
           </CTAButton>

--- a/frontend/tiggle/src/components/molecules/MainHeader/MainHeader.tsx
+++ b/frontend/tiggle/src/components/molecules/MainHeader/MainHeader.tsx
@@ -4,6 +4,8 @@ import { Link } from "react-router-dom";
 import { Avatar } from "antd";
 
 import Logo from "@/assets/logo_medium.svg";
+import { CTAButton } from "@/components/atoms";
+import useLogin from "@/hooks/useLogin";
 import useScroll from "@/hooks/useScroll";
 import {
   MainHeaderStyle,
@@ -12,6 +14,7 @@ import {
 } from "@/styles/components/MainHeaderStyle";
 
 export default function MainHeader() {
+  const { isLogin, profile, logIn } = useLogin();
   const { scrolling } = useScroll();
 
   return (
@@ -29,12 +32,25 @@ export default function MainHeader() {
               </div>
             </HeaderLeftStyle>
             <HeaderRightStyle>
-              <button className="right-bar-btn">
-                <Bell size={20} />
-              </button>
-              <button className="right-bar-btn">
-                <Avatar size={24} />
-              </button>
+              {isLogin ? (
+                <>
+                  <button className="right-bar-btn">
+                    <Bell size={20} />
+                  </button>
+                  <button className="right-bar-btn">
+                    <Avatar size={24} src={profile?.profileUrl} />
+                  </button>
+                </>
+              ) : (
+                <CTAButton
+                  variant="light"
+                  color="blue"
+                  size="sm"
+                  onClick={() => logIn()}
+                >
+                  로그인
+                </CTAButton>
+              )}
             </HeaderRightStyle>
           </div>
         </div>

--- a/frontend/tiggle/src/components/molecules/ReactionSection/ReactionSection.tsx
+++ b/frontend/tiggle/src/components/molecules/ReactionSection/ReactionSection.tsx
@@ -4,6 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 
 import ReactionButton from "@/components/atoms/ReactionButton/ReactionButton";
 import { ReactionApiService, ReactionSummaryDto } from "@/generated";
+import useLogin from "@/hooks/useLogin";
 import queryClient from "@/query/queryClient";
 import { ReactionSectionStyle } from "@/styles/components/ReactionSectionStyle";
 import { Reaction, ReactionType } from "@/types";
@@ -20,6 +21,7 @@ export default function ReactionSection({
   downCount,
   className,
 }: ReactionSectionProps) {
+  const { checkIsLogin } = useLogin();
   const [selectedReaction, setSelectedReaction] =
     useState<ReactionType>(undefined);
 
@@ -61,13 +63,17 @@ export default function ReactionSection({
         <ReactionButton
           reaction={Reaction.Up}
           number={upCount}
-          onClick={() => handleReactionButtonClick(Reaction.Up)}
+          onClick={() =>
+            checkIsLogin(() => handleReactionButtonClick(Reaction.Up))
+          }
           checked={selectedReaction === Reaction.Up}
         />
         <ReactionButton
           reaction={Reaction.Down}
           number={downCount}
-          onClick={() => handleReactionButtonClick(Reaction.Down)}
+          onClick={() =>
+            checkIsLogin(() => handleReactionButtonClick(Reaction.Down))
+          }
           checked={selectedReaction === Reaction.Down}
         />
       </div>

--- a/frontend/tiggle/src/generated/core/request.ts
+++ b/frontend/tiggle/src/generated/core/request.ts
@@ -2,14 +2,23 @@ import axios, { AxiosHeaders } from "axios";
 
 import { CancelablePromise, OpenAPIConfig } from "@/generated";
 import type { ApiRequestOptions } from "@/generated/core/ApiRequestOptions";
+import useCookie from "@/hooks/useCookie";
 
-const axiosInstance = axios.create({
-  baseURL: process.env.REACT_APP_API_URL,
-  headers: {
+const getAxiosInstance = () => {
+  const { getCookie } = useCookie();
+  const token = getCookie("Authorization");
+
+  const headers = {
     Accept: "application/json",
     "Content-Type": "application/json",
-  },
-});
+    ...(token && { Authorization: `Bearer ${token}` }),
+  };
+
+  return axios.create({
+    baseURL: process.env.REACT_APP_API_URL,
+    headers,
+  });
+};
 
 export const request = <T>(
   config: OpenAPIConfig,
@@ -20,7 +29,7 @@ export const request = <T>(
     const queryString = getQueryString(options.query);
     const url = `${urlWithPath}${queryString}`;
 
-    axiosInstance
+    getAxiosInstance()
       .request({
         url,
         data: options.body,

--- a/frontend/tiggle/src/hooks/useLogin.tsx
+++ b/frontend/tiggle/src/hooks/useLogin.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { useDispatch } from "react-redux";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import continueUrlStore from "@/store/continueUrl";
+
+import useCookie from "./useCookie";
+
+export default function useLogin() {
+  const { getCookie, removeCookie } = useCookie();
+  const authorization = getCookie("Authorization");
+
+  const isLogin = useMemo(() => !!authorization, [authorization]);
+
+  const logOut = () => {
+    removeCookie("Authorization");
+  };
+
+  const checkIsLogin = (callback: () => void) => {
+    if (isLogin) {
+      callback();
+    } else {
+      const navigate = useNavigate();
+      const dispatch = useDispatch();
+      const location = useLocation();
+
+      dispatch(continueUrlStore.actions.creators.set(location.pathname));
+      navigate("/login");
+    }
+  };
+
+  return { isLogin, logOut, checkIsLogin };
+}

--- a/frontend/tiggle/src/hooks/useLogin.tsx
+++ b/frontend/tiggle/src/hooks/useLogin.tsx
@@ -2,32 +2,49 @@ import { useMemo } from "react";
 import { useDispatch } from "react-redux";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import { useQuery } from "@tanstack/react-query";
+
+import { MemberApiControllerService } from "@/generated";
 import continueUrlStore from "@/store/continueUrl";
 
 import useCookie from "./useCookie";
 
-export default function useLogin() {
-  const { getCookie, removeCookie } = useCookie();
-  const authorization = getCookie("Authorization");
+const TEMP_USER_ID = 1;
 
+export default function useLogin() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { getCookie, removeCookie } = useCookie();
+
+  const authorization = getCookie("Authorization");
   const isLogin = useMemo(() => !!authorization, [authorization]);
+
+  const { data: profile } = useQuery(
+    ["profile"],
+    async () => MemberApiControllerService.getMe(TEMP_USER_ID),
+    {
+      enabled: isLogin,
+      staleTime: 1000 * 60 * 10,
+    },
+  );
+
+  const logIn = () => {
+    dispatch(continueUrlStore.actions.creators.set(location.pathname));
+    navigate("/login");
+  };
 
   const logOut = () => {
     removeCookie("Authorization");
   };
 
-  const checkIsLogin = (callback: () => void) => {
+  const checkIsLogin = (callback?: () => void) => {
     if (isLogin) {
-      callback();
+      callback?.();
     } else {
-      const navigate = useNavigate();
-      const dispatch = useDispatch();
-      const location = useLocation();
-
-      dispatch(continueUrlStore.actions.creators.set(location.pathname));
-      navigate("/login");
+      logIn();
     }
   };
 
-  return { isLogin, logOut, checkIsLogin };
+  return { isLogin, profile, logIn, logOut, checkIsLogin };
 }

--- a/frontend/tiggle/src/index.tsx
+++ b/frontend/tiggle/src/index.tsx
@@ -6,11 +6,12 @@ import { RouterProvider } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { ConfigProvider } from "antd";
+import { PersistGate } from "redux-persist/integration/react";
 import { ThemeProvider } from "styled-components";
 
 import router from "@/Router";
 import queryClient from "@/query/queryClient";
-import { store } from "@/store";
+import { store, persistedStore } from "@/store";
 import { GlobalStyle } from "@/styles/config/GlobalStyle";
 import { antTheme } from "@/styles/config/antTheme";
 import { mq } from "@/styles/config/mediaQueries";
@@ -23,13 +24,15 @@ root.render(
   <QueryClientProvider client={queryClient}>
     <CookiesProvider>
       <Provider store={store}>
-        <ThemeProvider theme={{ ...theme, mq }}>
-          <ConfigProvider theme={antTheme}>
-            {process.env.NODE_ENV === "development" && <ReactQueryDevtools />}
-            <GlobalStyle />
-            <RouterProvider router={router} />
-          </ConfigProvider>
-        </ThemeProvider>
+        <PersistGate persistor={persistedStore}>
+          <ThemeProvider theme={{ ...theme, mq }}>
+            <ConfigProvider theme={antTheme}>
+              {process.env.NODE_ENV === "development" && <ReactQueryDevtools />}
+              <GlobalStyle />
+              <RouterProvider router={router} />
+            </ConfigProvider>
+          </ThemeProvider>
+        </PersistGate>
       </Provider>
     </CookiesProvider>
   </QueryClientProvider>,

--- a/frontend/tiggle/src/pages/CreatePage/index.tsx
+++ b/frontend/tiggle/src/pages/CreatePage/index.tsx
@@ -23,6 +23,7 @@ import {
 import { useMessage } from "@/templates/GeneralTemplate";
 import { TxType } from "@/types";
 import { convertTxTypeToWord } from "@/utils/txType";
+import withAuth from "@/utils/withAuth";
 
 import { createTransaction, TransactionFormData } from "./request";
 
@@ -111,7 +112,7 @@ const CreatePage = ({ type }: CreatePageProps) => {
   );
 };
 
-export default CreatePage;
+export default withAuth(CreatePage, "protected");
 
 interface TransactionPreviewCellProps
   extends Pick<TransactionRespDto, "type" | "content" | "reason" | "amount"> {}

--- a/frontend/tiggle/src/pages/LoginPage.tsx
+++ b/frontend/tiggle/src/pages/LoginPage.tsx
@@ -2,6 +2,7 @@ import SocialLoginButton from "@/components/atoms/SocialLoginButton/SocialLoginB
 import LoginHeader from "@/components/molecules/LoginHeader/LoginHeader";
 import useCookie from "@/hooks/useCookie";
 import { LoginPageStyle } from "@/styles/components/LoginPageStyle";
+import withAuth from "@/utils/withAuth";
 
 const LoginPage = () => {
   const { setCookie } = useCookie();
@@ -28,4 +29,4 @@ const LoginPage = () => {
   );
 };
 
-export default LoginPage;
+export default withAuth(LoginPage, "auth");

--- a/frontend/tiggle/src/pages/LoginRedirectPage.tsx
+++ b/frontend/tiggle/src/pages/LoginRedirectPage.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
+
+import { Loading } from "@/components/atoms";
+import useLogin from "@/hooks/useLogin";
+import { RootState } from "@/store";
+import continueUrlStore from "@/store/continueUrl";
+
+const LoginRedirectPage = () => {
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const { isLogin } = useLogin();
+  const { url } = useSelector((state: RootState) => state.continueUrl);
+
+  useEffect(() => {
+    if (isLogin) {
+      navigate(url ?? "/");
+      dispatch(continueUrlStore.actions.creators.reset());
+    } else {
+      navigate("/login");
+      // messageApi.error("로그인에 실패했습니다. 다시 시도해주세요.");
+    }
+  }, []);
+
+  return (
+    <div>
+      <Loading />
+    </div>
+  );
+};
+
+export default LoginRedirectPage;

--- a/frontend/tiggle/src/query/openapi-request.ts
+++ b/frontend/tiggle/src/query/openapi-request.ts
@@ -2,14 +2,23 @@ import axios, { AxiosHeaders } from "axios";
 
 import { CancelablePromise, OpenAPIConfig } from "@/generated";
 import type { ApiRequestOptions } from "@/generated/core/ApiRequestOptions";
+import useCookie from "@/hooks/useCookie";
 
-const axiosInstance = axios.create({
-  baseURL: process.env.REACT_APP_API_URL,
-  headers: {
+const getAxiosInstance = () => {
+  const { getCookie } = useCookie();
+  const token = getCookie("Authorization");
+
+  const headers = {
     Accept: "application/json",
     "Content-Type": "application/json",
-  },
-});
+    ...(token && { Authorization: `Bearer ${token}` }),
+  };
+
+  return axios.create({
+    baseURL: process.env.REACT_APP_API_URL,
+    headers,
+  });
+};
 
 export const request = <T>(
   config: OpenAPIConfig,
@@ -20,7 +29,7 @@ export const request = <T>(
     const queryString = getQueryString(options.query);
     const url = `${urlWithPath}${queryString}`;
 
-    axiosInstance
+    getAxiosInstance()
       .request({
         url,
         data: options.body,

--- a/frontend/tiggle/src/query/queryClient.ts
+++ b/frontend/tiggle/src/query/queryClient.ts
@@ -8,7 +8,7 @@ const queryClient = new QueryClient({
       refetchIntervalInBackground: false,
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
-      staleTime: 1000 * 60 * 5,
+      staleTime: 1000 * 60,
     },
     mutations: {
       retry: false,

--- a/frontend/tiggle/src/store/continueUrl/actions.ts
+++ b/frontend/tiggle/src/store/continueUrl/actions.ts
@@ -1,11 +1,13 @@
 const SET_CONTINUE_URL = "SET_CONTINUE_URL" as const;
 const GET_CONTINUE_URL = "GET_CONTINUE_URL" as const;
-export const type = { SET_CONTINUE_URL, GET_CONTINUE_URL };
+const RESET_CONTINUE_URL = "RESET_CONTINUE_URL" as const;
+export const type = { SET_CONTINUE_URL, GET_CONTINUE_URL, RESET_CONTINUE_URL };
 type ActionType = (typeof type)[keyof typeof type];
 
 const set = (url: string) => ({ type: SET_CONTINUE_URL, payload: url });
 const get = () => ({ type: GET_CONTINUE_URL });
-export const creators = { set, get };
+const reset = () => ({ type: RESET_CONTINUE_URL });
+export const creators = { set, get, reset };
 
 export type ContinueUrlActionType = {
   type: ActionType;

--- a/frontend/tiggle/src/store/continueUrl/actions.ts
+++ b/frontend/tiggle/src/store/continueUrl/actions.ts
@@ -1,0 +1,13 @@
+const SET_CONTINUE_URL = "SET_CONTINUE_URL" as const;
+const GET_CONTINUE_URL = "GET_CONTINUE_URL" as const;
+export const type = { SET_CONTINUE_URL, GET_CONTINUE_URL };
+type ActionType = (typeof type)[keyof typeof type];
+
+const set = (url: string) => ({ type: SET_CONTINUE_URL, payload: url });
+const get = () => ({ type: GET_CONTINUE_URL });
+export const creators = { set, get };
+
+export type ContinueUrlActionType = {
+  type: ActionType;
+  payload?: string;
+};

--- a/frontend/tiggle/src/store/continueUrl/index.ts
+++ b/frontend/tiggle/src/store/continueUrl/index.ts
@@ -1,0 +1,7 @@
+import { type, creators } from "./actions";
+import reducer from "./reducer";
+
+export default {
+  reducer,
+  actions: { type, creators },
+};

--- a/frontend/tiggle/src/store/continueUrl/reducer.ts
+++ b/frontend/tiggle/src/store/continueUrl/reducer.ts
@@ -15,6 +15,10 @@ const continueUrlReducer = (
       return {
         url: action.payload,
       };
+    case type.RESET_CONTINUE_URL:
+      return {
+        url: undefined,
+      };
     default:
       return state;
   }

--- a/frontend/tiggle/src/store/continueUrl/reducer.ts
+++ b/frontend/tiggle/src/store/continueUrl/reducer.ts
@@ -1,0 +1,23 @@
+import { ContinueUrlActionType, type } from "./actions";
+
+export interface ContinueUrlState {
+  url?: string;
+}
+
+const initialState: ContinueUrlState = {};
+
+const continueUrlReducer = (
+  state = initialState,
+  action: ContinueUrlActionType,
+) => {
+  switch (action.type) {
+    case type.SET_CONTINUE_URL:
+      return {
+        url: action.payload,
+      };
+    default:
+      return state;
+  }
+};
+
+export default continueUrlReducer;

--- a/frontend/tiggle/src/store/index.ts
+++ b/frontend/tiggle/src/store/index.ts
@@ -1,5 +1,14 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
-import { persistReducer, persistStore } from "redux-persist";
+import {
+  persistReducer,
+  persistStore,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from "redux-persist";
 import storage from "redux-persist/lib/storage"; // defaults to localStorage for web
 
 import continueUrl from "@/store/continueUrl";
@@ -9,6 +18,7 @@ import detailPageStore from "@/store/detailPage";
 const persistConfig = {
   key: "root",
   storage,
+  version: 1,
   whitelist: ["continueUrl"],
 };
 
@@ -21,6 +31,12 @@ const persistedReducer = persistReducer(persistConfig, reducers);
 
 export const store = configureStore({
   reducer: persistedReducer,
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, REGISTER, PAUSE, PERSIST, PURGE],
+      },
+    }),
   devTools: process.env.NODE_ENV !== "production",
 });
 export const persistedStore = persistStore(store);

--- a/frontend/tiggle/src/store/index.ts
+++ b/frontend/tiggle/src/store/index.ts
@@ -1,15 +1,29 @@
-import { configureStore } from "@reduxjs/toolkit";
+import { combineReducers, configureStore } from "@reduxjs/toolkit";
+import { persistReducer, persistStore } from "redux-persist";
+import storage from "redux-persist/lib/storage"; // defaults to localStorage for web
 
+import continueUrl from "@/store/continueUrl";
 import getDataReducer from "@/store/data/reducer";
 import detailPageStore from "@/store/detailPage";
 
+const persistConfig = {
+  key: "root",
+  storage,
+  whitelist: ["continueUrl"],
+};
+
+const reducers = combineReducers({
+  data: getDataReducer,
+  detailPage: detailPageStore.reducer,
+  continueUrl: continueUrl.reducer,
+});
+const persistedReducer = persistReducer(persistConfig, reducers);
+
 export const store = configureStore({
-  reducer: {
-    data: getDataReducer,
-    detailPage: detailPageStore.reducer,
-  },
+  reducer: persistedReducer,
   devTools: process.env.NODE_ENV !== "production",
 });
+export const persistedStore = persistStore(store);
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;

--- a/frontend/tiggle/src/styles/components/CTAButtonStyle.tsx
+++ b/frontend/tiggle/src/styles/components/CTAButtonStyle.tsx
@@ -14,6 +14,16 @@ export const CTAButtonStyle = styled.button`
   align-items: center;
   gap: 8px;
 
+  transition:
+    background-color 0.1s ease,
+    color 0.1s ease;
+
+  &.sm {
+    padding: 0 16px;
+    height: 28px;
+    ${({ theme }) => expandTypography(theme.typography.body.small.bold)}
+  }
+
   &.md {
     padding: 0 20px;
     height: 32px;
@@ -26,6 +36,10 @@ export const CTAButtonStyle = styled.button`
     ${({ theme }) => expandTypography(theme.typography.body.medium.bold)}
   }
 
+  &:disabled {
+    cursor: not-allowed;
+  }
+
   ${({ theme }) => {
     return CTAButtonColors.map(colorKey => {
       return css`
@@ -33,14 +47,23 @@ export const CTAButtonStyle = styled.button`
           &.primary {
             background-color: ${theme.color[colorKey][600].value};
             color: ${theme.color.white.value};
+            &:disabled {
+              background-color: ${theme.color[colorKey][400].value};
+            }
           }
           &.secondary {
             background-color: ${theme.color[colorKey][500].value};
             color: ${theme.color.white.value};
+            &:disabled {
+              background-color: ${theme.color[colorKey][300].value};
+            }
           }
           &.light {
             background-color: ${theme.color[colorKey][100].value};
             color: ${theme.color[colorKey][600].value};
+            &:disabled {
+              color: ${theme.color[colorKey][400].value};
+            }
           }
         }
       `;

--- a/frontend/tiggle/src/styles/components/CommentCellStyle.tsx
+++ b/frontend/tiggle/src/styles/components/CommentCellStyle.tsx
@@ -33,11 +33,10 @@ export const CommentSenderStyle = styled.div`
   gap: 8px;
   align-items: center;
 
-  .profile {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
+  .ant-avatar {
     background-color: ${({ theme }) => theme.color.bluishGray[300].value};
+    background-image: url("/assets/user-placeholder.png");
+    background-size: cover;
   }
 
   .name {

--- a/frontend/tiggle/src/utils/withAuth.tsx
+++ b/frontend/tiggle/src/utils/withAuth.tsx
@@ -1,0 +1,39 @@
+import { useDispatch } from "react-redux";
+import { Navigate, useLocation } from "react-router-dom";
+
+import useLogin from "@/hooks/useLogin";
+import continueUrlStore from "@/store/continueUrl";
+
+type Role = "protected" | "auth";
+
+const LOGIN_PATH = "/login";
+
+const withAuth =
+  <Props extends object>(Component: React.ComponentType<Props>, role: Role) =>
+  (props: Props) => {
+    const dispatch = useDispatch();
+    const location = useLocation();
+
+    const { isLogin } = useLogin();
+
+    const recordContinueUrl = () =>
+      dispatch(continueUrlStore.actions.creators.set(location.pathname));
+
+    switch (role) {
+      case "protected":
+        if (!isLogin) {
+          recordContinueUrl();
+          return <Navigate to={LOGIN_PATH} replace />;
+        } else {
+          return <Component {...(props as Props)} />;
+        }
+      case "auth":
+        if (isLogin) {
+          return <Navigate to="/" replace />; //로그인 시 로그인 페이지 진입 불가
+        } else {
+          return <Component {...(props as Props)} />;
+        }
+    }
+  };
+
+export default withAuth;


### PR DESCRIPTION
## 작업 내용
#### ContinueUrl store 작성
  - 페이지가 reload된 후에도 store의 값이 유지되어야 함으로, redux-persist를 적용했습니다.
  - redux-persist를 적용하면서 non-serialiazable 관련 에러가 발생해, src/store/index.ts에 몇가지 설정을 추가했습니다. ([참고자료](https://redux-toolkit.js.org/usage/usage-guide#use-with-redux-persist))

#### loginRedirectPage 작성
  - `/login/success`에 해당하는 페이지입니다.
  - cookie에 토큰이 있으면 continueUrl의 주소로 리다이렉트 합니다.
  - 토큰이 없으면 에러 메세지와 함께 로그인 페이지로 리다이렉트 합니다.

#### withAuth 작성
  - Higher order component로 해당 페이지에 접근하기 이전에 로그인 관련된 상태를 확인합니다.
  - 로그인해야 접근할 수 있는 페이지의 경우, role parameter에 'protected'를 입력하고, 로그인을 하는 페이지의 경우 'auth'를 입력합니다.
  - 'protected'의 경우 로그인이 되어 있으면 해당 페이지로 이동, 아닐 경우 현재 url을 continueUrl에 저장한 후 로그인 페이지로 redirect 합니다.
  - 'auth'의 경우 로그인이 안되어 있으면 해당 페이지로 이동, 로그인이 되어 있는 경우 메인 페이지로 redirect 합니다.
    - 로그인한 유저가 로그인 페이지에 접근하는 것이 부자연스럽다고 생각하여 추가한 기능인데, 혹시 너무 로직이 복잡해지는 것 같으면 제외해도 좋습니다.

#### useLogin hook을 작성했습니다.
  - isLogin: cookie의 토큰 여부에 따른 로그인 상태
  - profile: 사용자 정보 (isLogin시에만 존재)
  - logIn: 현재 주소를 continueUrl에 저장한 후 로그인 페이지로 이동
  - logOut: cookie의 토큰 삭제
  - checkAuth: isLogin 여부를 확인하고, 로그인 된 경우 입력된 callback을 실행, 아닐 경우 continueUrl 저장 후 로그인 페이지로 이동

#### 로그인 여부에 따른 UI 및 동작 변경 구현
- mainHeader: 로그인 시 user Icon & notification button, 비로그인시 로그인 버튼
- detailPage: 로그인 시 모든 동작 가능, 비로그인시 댓글, 리액션 버튼 클릭시 로그인 페이지로 이동
- openapi-request > getAxiosInstance(): cookie의 토큰 유무에 따라 headers.Authorization 구분