### PR TITLE
[FE] 마이페이지 상세 페이지 (내 정보 수정, 내 거래 모아보기, 자산/카테고리 관리)

### DIFF
--- a/frontend/tiggle/src/Router.tsx
+++ b/frontend/tiggle/src/Router.tsx
@@ -14,6 +14,7 @@ import MainPage from "@/pages/MainPage";
 import MyPage from "@/pages/MyPage";
 import MyProfilePage from "@/pages/MyProfilePage";
 import { loader as myProfilePageLoader } from "@/pages/MyProfilePage/controller";
+import MyTransactionsPage from "@/pages/MyTransactionsPage";
 import NotFoundPage from "@/pages/NotFoundPage";
 import queryClient from "@/query/queryClient";
 import GeneralTemplate from "@/templates/GeneralTemplate";
@@ -49,6 +50,11 @@ export default createBrowserRouter(
           path="/mypage/profile"
           element={<MyProfilePage />}
           loader={myProfilePageLoader(queryClient)}
+          errorElement={<div>error</div>}
+        />
+        <Route
+          path="/mypage/my-transactions"
+          element={<MyTransactionsPage />}
           errorElement={<div>error</div>}
         />
         <Route path="/" element={<MainPage />} />

--- a/frontend/tiggle/src/Router.tsx
+++ b/frontend/tiggle/src/Router.tsx
@@ -19,6 +19,8 @@ import NotFoundPage from "@/pages/NotFoundPage";
 import queryClient from "@/query/queryClient";
 import GeneralTemplate from "@/templates/GeneralTemplate";
 
+import AssetSettingPage from "./pages/SettingPage/AssetSettingPage";
+
 export default createBrowserRouter(
   createRoutesFromElements(
     <>
@@ -55,6 +57,11 @@ export default createBrowserRouter(
         <Route
           path="/mypage/my-transactions"
           element={<MyTransactionsPage />}
+          errorElement={<div>error</div>}
+        />
+        <Route
+          path="/mypage/setting/asset"
+          element={<AssetSettingPage />}
           errorElement={<div>error</div>}
         />
         <Route path="/" element={<MainPage />} />

--- a/frontend/tiggle/src/Router.tsx
+++ b/frontend/tiggle/src/Router.tsx
@@ -12,6 +12,8 @@ import LoginPage from "@/pages/LoginPage";
 import LoginRedirectPage from "@/pages/LoginRedirectPage";
 import MainPage from "@/pages/MainPage";
 import MyPage from "@/pages/MyPage";
+import MyProfilePage from "@/pages/MyProfilePage";
+import { loader as myProfilePageLoader } from "@/pages/MyProfilePage/controller";
 import NotFoundPage from "@/pages/NotFoundPage";
 import queryClient from "@/query/queryClient";
 import GeneralTemplate from "@/templates/GeneralTemplate";
@@ -43,6 +45,12 @@ export default createBrowserRouter(
           errorElement={<div>error</div>}
         />
         <Route path="/mypage" element={<MyPage />} />
+        <Route
+          path="/mypage/profile"
+          element={<MyProfilePage />}
+          loader={myProfilePageLoader(queryClient)}
+          errorElement={<div>error</div>}
+        />
         <Route path="/" element={<MainPage />} />
       </Route>
       <Route path="/login" element={<LoginPage />} />

--- a/frontend/tiggle/src/Router.tsx
+++ b/frontend/tiggle/src/Router.tsx
@@ -20,6 +20,8 @@ import queryClient from "@/query/queryClient";
 import GeneralTemplate from "@/templates/GeneralTemplate";
 
 import AssetSettingPage from "./pages/SettingPage/AssetSettingPage";
+import IncomeCategorySettingPage from "./pages/SettingPage/IncomeCategorySettingPage";
+import OutcomeCategorySettingPage from "./pages/SettingPage/OutcomeCategorySettingPage";
 
 export default createBrowserRouter(
   createRoutesFromElements(
@@ -62,6 +64,16 @@ export default createBrowserRouter(
         <Route
           path="/mypage/setting/asset"
           element={<AssetSettingPage />}
+          errorElement={<div>error</div>}
+        />
+        <Route
+          path="/mypage/setting/income-category"
+          element={<IncomeCategorySettingPage />}
+          errorElement={<div>error</div>}
+        />
+        <Route
+          path="/mypage/setting/outcome-category"
+          element={<OutcomeCategorySettingPage />}
           errorElement={<div>error</div>}
         />
         <Route path="/" element={<MainPage />} />

--- a/frontend/tiggle/src/components/atoms/Alert/Alert.stories.tsx
+++ b/frontend/tiggle/src/components/atoms/Alert/Alert.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import Alert from "./Alert";
+
+export default {
+  title: "atoms/Alert",
+  component: Alert,
+} as Meta<typeof Alert>;
+
+type Story = StoryObj<typeof Alert>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    onClose: () => console.log("close"),
+    confirm: {
+      label: "확인",
+      onClick: () => console.log("confirm"),
+    },
+    cancel: {
+      label: "취소",
+      onClick: () => console.log("cancel"),
+    },
+    children: <p>hello</p>,
+  },
+};

--- a/frontend/tiggle/src/components/atoms/Alert/Alert.tsx
+++ b/frontend/tiggle/src/components/atoms/Alert/Alert.tsx
@@ -1,0 +1,76 @@
+import { PropsWithChildren, useEffect, useRef, useState } from "react";
+
+import cn from "classnames";
+
+import useOnClickOutside from "@/hooks/useOnClickOutside";
+
+import { OverlayContainerStyle, AlertStyle } from "./AlertStyle";
+import CTAButton from "../CTAButton/CTAButton";
+
+interface OverlayProps {
+  isOpen: boolean;
+}
+
+interface AlertProps extends PropsWithChildren, OverlayProps {
+  onClose: () => void;
+  confirm: {
+    label: string;
+    onClick: () => void;
+  };
+  cancel?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+const Alert = ({ isOpen, children, onClose, confirm, cancel }: AlertProps) => {
+  const [isMount, setIsMount] = useState(isOpen);
+  const unmountRef = useRef<() => void | null>(null);
+  const alertRef = useRef<HTMLDivElement | null>(null);
+  useOnClickOutside(alertRef, onClose);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsMount(true);
+    }
+    unmountRef.current = () => {
+      if (!isOpen) {
+        setIsMount(false);
+      }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const animationendId = () => unmountRef.current?.();
+    window.addEventListener("animationend", animationendId);
+    return () => window.removeEventListener("animationend", animationendId);
+  }, []);
+
+  return isMount ? (
+    <OverlayContainerStyle>
+      <div className={cn("overlay", isOpen ? "open" : "close")} />
+
+      <AlertStyle ref={alertRef} className={cn(isOpen ? "open" : "close")}>
+        <div className="alert-content">{children}</div>
+        <div className="alert-footer">
+          {cancel && (
+            <CTAButton
+              className="cancelBtn"
+              variant="light"
+              color="bluishGray"
+              fullWidth
+              onClick={cancel.onClick}
+            >
+              {cancel.label}
+            </CTAButton>
+          )}
+          <CTAButton className="confirmBtn" fullWidth onClick={confirm.onClick}>
+            {confirm.label}
+          </CTAButton>
+        </div>
+      </AlertStyle>
+    </OverlayContainerStyle>
+  ) : null;
+};
+
+export default Alert;

--- a/frontend/tiggle/src/components/atoms/Alert/AlertStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/Alert/AlertStyle.tsx
@@ -1,0 +1,138 @@
+import styled, { keyframes } from "styled-components";
+
+const overlayFadeIn = keyframes`
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+`;
+
+const overlayFadeOut = keyframes`
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+`;
+
+export const OverlayContainerStyle = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 999;
+
+  .overlay {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.32);
+
+    &.open {
+      animation: ${overlayFadeIn} 0.2s ease;
+    }
+
+    &.close {
+      animation: ${overlayFadeOut} 0.2s ease forwards;
+    }
+  }
+`;
+
+const alertSlideUp = keyframes`
+    0% {
+        transform: translateY(100%);
+    } 
+    100% {
+        transform: translateY(0%);
+    }
+`;
+
+const alertSlideDown = keyframes`
+    0% {
+        transform: translateY(0%);
+    }
+    50% {
+        opacity: 1;
+    }
+    100% {
+        transform: translateY(100%);
+        opacity: 0;
+    }
+`;
+
+const alertFadeIn = keyframes`
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+`;
+
+const alertFadeOut = keyframes`
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+`;
+
+export const AlertStyle = styled.div`
+  padding: 32px 24px 20px;
+  min-height: 180px;
+  max-height: 560px;
+  background-color: ${({ theme }) => theme.color.white.value};
+  border-radius: 12px;
+
+  display: flex;
+  flex-direction: column;
+
+  position: absolute;
+  left: 24px;
+  right: 24px;
+  bottom: 60px;
+
+  &.open {
+    animation: ${alertSlideUp} 0.3s cubic-bezier(0.29, 1.05, 0.55, 1);
+  }
+  &.close {
+    animation: ${alertSlideDown} 0.2s ease forwards;
+  }
+
+  .alert-content {
+    flex-grow: 1;
+    overflow-y: scroll;
+  }
+
+  .alert-footer {
+    width: 100%;
+    display: flex;
+    gap: 8px;
+
+    flex-shrink: 0;
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    width: 380px;
+    padding: 48px 32px 24px;
+    border-radius: 16px;
+
+    top: 200px;
+    left: 50%;
+    right: unset;
+    bottom: unset;
+    transform: translateX(-50%);
+
+    &.open {
+      animation: ${alertFadeIn} 0.2s ease;
+    }
+    &.close {
+      animation: ${alertFadeOut} 0.1s ease forwards;
+    }
+  }
+`;

--- a/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheet.stories.tsx
+++ b/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,25 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import BottomSheet from "./BottomSheet";
+
+export default {
+  title: "atoms/BottomSheet",
+  component: BottomSheet,
+} as Meta<typeof BottomSheet>;
+
+type Story = StoryObj<typeof BottomSheet>;
+
+export const Default: Story = {
+  args: {
+    isOpen: true,
+    header: {
+      title: "선택하기",
+    },
+    confirm: {
+      label: "확인",
+      onClick: () => console.log("확인"),
+    },
+    onClose: () => console.log("close"),
+    children: <p>hello</p>,
+  },
+};

--- a/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheet.tsx
+++ b/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheet.tsx
@@ -69,14 +69,23 @@ const BottomSheet = ({
         {header && (
           <BottomSheetHeaderStyle>
             <p className="title">{header.title}</p>
-            {header.reset && <button className="reset">초기화</button>}
+            {header.reset && (
+              <button className="reset" type="button">
+                초기화
+              </button>
+            )}
           </BottomSheetHeaderStyle>
         )}
 
         <div className="bottom-sheet-content">{children}</div>
 
         <BottomSheetFooterStyle>
-          <CTAButton fullWidth size="lg" onClick={confirm.onClick}>
+          <CTAButton
+            fullWidth
+            size="lg"
+            onClick={confirm.onClick}
+            type="button"
+          >
             {confirm.label}
           </CTAButton>
         </BottomSheetFooterStyle>

--- a/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheet.tsx
+++ b/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,88 @@
+import { PropsWithChildren, useEffect, useRef, useState } from "react";
+
+import cn from "classnames";
+
+import { CTAButton } from "@/components/atoms";
+import useOnClickOutside from "@/hooks/useOnClickOutside";
+
+import {
+  BottomSheetStyle,
+  BottomSheetContainerStyle,
+  BottomSheetHeaderStyle,
+  BottomSheetFooterStyle,
+} from "./BottomSheetStyle";
+
+interface OverlayProps {
+  isOpen: boolean;
+}
+
+interface BottomSheetProps extends PropsWithChildren, OverlayProps {
+  header?: {
+    title: React.ReactNode;
+    reset?: boolean;
+  };
+  confirm: {
+    label: string;
+    onClick: () => void;
+  };
+  onClose: () => void;
+}
+
+const BottomSheet = ({
+  isOpen,
+  header,
+  confirm,
+  onClose,
+  children,
+}: BottomSheetProps) => {
+  const [isMount, setIsMount] = useState(isOpen);
+  const unmountRef = useRef<() => void | null>(null);
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+
+  useOnClickOutside(sheetRef, onClose);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsMount(true);
+    }
+    unmountRef.current = () => {
+      if (!isOpen) {
+        setIsMount(false);
+      }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const animationendId = () => unmountRef.current?.();
+    window.addEventListener("animationend", animationendId);
+    return () => window.removeEventListener("animationend", animationendId);
+  }, []);
+
+  return isMount ? (
+    <BottomSheetContainerStyle>
+      <div className={cn("bottom-sheet-overlay", isOpen ? "open" : "close")} />
+
+      <BottomSheetStyle
+        ref={sheetRef}
+        className={cn(isOpen ? "open" : "close")}
+      >
+        {header && (
+          <BottomSheetHeaderStyle>
+            <p className="title">{header.title}</p>
+            {header.reset && <button className="reset">초기화</button>}
+          </BottomSheetHeaderStyle>
+        )}
+
+        <div className="bottom-sheet-content">{children}</div>
+
+        <BottomSheetFooterStyle>
+          <CTAButton fullWidth size="lg" onClick={confirm.onClick}>
+            {confirm.label}
+          </CTAButton>
+        </BottomSheetFooterStyle>
+      </BottomSheetStyle>
+    </BottomSheetContainerStyle>
+  ) : null;
+};
+
+export default BottomSheet;

--- a/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheetStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheetStyle.tsx
@@ -45,6 +45,7 @@ export const BottomSheetContainerStyle = styled.div`
 
   .bottom-sheet-content {
     flex-grow: 1;
+    overflow-y: scroll;
   }
 `;
 

--- a/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheetStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/BottomSheet/BottomSheetStyle.tsx
@@ -1,0 +1,109 @@
+import styled, { keyframes } from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+const bottomSheetOverlayFadeIn = keyframes`
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+`;
+
+const bottomSheetOverlayFadeOut = keyframes`
+    0% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+    }
+`;
+
+export const BottomSheetContainerStyle = styled.div`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 999;
+
+  .bottom-sheet-overlay {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    background-color: rgba(0, 0, 0, 0.32);
+
+    &.open {
+      animation: ${bottomSheetOverlayFadeIn} 0.3s ease;
+    }
+
+    &.close {
+      animation: ${bottomSheetOverlayFadeOut} 0.3s ease forwards;
+    }
+  }
+
+  .bottom-sheet-content {
+    flex-grow: 1;
+  }
+`;
+
+const bottomSheetSlideUp = keyframes`
+    0% {
+        transform: translateY(100%);
+    }
+    100% {
+        transform: translateY(0);
+    }
+`;
+
+const bottomSheetSlideDown = keyframes`
+    0% {
+        transform: translateY(0%);
+    }
+    100% {
+        transform: translateY(100%);
+    }
+`;
+
+export const BottomSheetStyle = styled.div`
+  width: 100%;
+  height: 440px; // TODO: mobile 맞춰 사이즈 변경
+  max-height: 100%;
+  background-color: ${({ theme }) => theme.color.white.value};
+  border-radius: 12px 12px 0 0;
+
+  display: flex;
+  flex-direction: column;
+
+  position: absolute;
+  bottom: 0;
+
+  &.open {
+    animation: ${bottomSheetSlideUp} 0.5s cubic-bezier(0.29, 1.05, 0.55, 1);
+  }
+
+  &.close {
+    animation: ${bottomSheetSlideDown} 0.3s ease forwards;
+  }
+`;
+
+export const BottomSheetHeaderStyle = styled.div`
+  padding: 24px;
+  display: flex;
+  justify-content: space-between;
+
+  .title {
+    ${({ theme }) => expandTypography(theme.typography.body.large.bold)}
+    color: ${({ theme }) => theme.color.bluishGray[800].value};
+  }
+
+  .reset {
+    ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+    color: ${({ theme }) => theme.color.blue[500].value};
+  }
+`;
+
+export const BottomSheetFooterStyle = styled.div`
+  padding: 8px 24px 24px;
+`;

--- a/frontend/tiggle/src/components/atoms/PopOver/PopOver.stories.tsx
+++ b/frontend/tiggle/src/components/atoms/PopOver/PopOver.stories.tsx
@@ -1,0 +1,62 @@
+import { useState } from "react";
+
+import { Meta, StoryObj } from "@storybook/react";
+import styled from "styled-components";
+
+import { CTAButton } from "@/components/atoms";
+
+import PopOver from "./PopOver";
+
+export default {
+  title: "atoms/PopOver",
+  component: PopOver,
+} as Meta<typeof PopOver>;
+
+type Story = StoryObj<typeof PopOver>;
+
+const PopOverStorybookChildrenStyle = styled.ul`
+  li {
+    padding: 12px 16px;
+    &:not(:last-child) {
+      border-bottom: 1px solid #dfe4ec;
+    }
+  }
+`;
+
+const PopOverStorybookContainerStyle = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  position: relative;
+`;
+
+export const Default: Story = {
+  args: {
+    header: {
+      title: "선택하기",
+      reset: true,
+    },
+    children: (
+      <PopOverStorybookChildrenStyle>
+        <li>option 1</li>
+        <li>option 2</li>
+        <li>option 3</li>
+        <li>option 4</li>
+        <li>option 5</li>
+        <li>option 6</li>
+      </PopOverStorybookChildrenStyle>
+    ),
+  },
+  render: args => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    const toggle = () => setIsOpen(!isOpen);
+
+    return (
+      <PopOverStorybookContainerStyle>
+        <CTAButton onClick={toggle}>toggle</CTAButton>
+        <PopOver {...args} isOpen={isOpen} />
+      </PopOverStorybookContainerStyle>
+    );
+  },
+};

--- a/frontend/tiggle/src/components/atoms/PopOver/PopOver.tsx
+++ b/frontend/tiggle/src/components/atoms/PopOver/PopOver.tsx
@@ -1,0 +1,52 @@
+import { PropsWithChildren, useEffect, useRef, useState } from "react";
+
+import cn from "classnames";
+
+import { PopoverStyle, PopoverHeaderStyle } from "./PopOverStyle";
+
+interface OverlayProps {
+  isOpen: boolean;
+}
+
+interface PopOverProps extends PropsWithChildren, OverlayProps {
+  header?: {
+    title: React.ReactNode;
+    reset?: boolean;
+  };
+}
+
+const PopOver = ({ isOpen, header, children }: PopOverProps) => {
+  const [isMount, setIsMount] = useState(isOpen);
+  const unmountRef = useRef<() => void | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsMount(true);
+    }
+    unmountRef.current = () => {
+      if (!isOpen) {
+        setIsMount(false);
+      }
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    const animationendId = () => unmountRef.current?.();
+    window.addEventListener("animationend", animationendId);
+    return () => window.removeEventListener("animationend", animationendId);
+  }, []);
+
+  return isMount ? (
+    <PopoverStyle className={cn(isOpen ? "open" : "close")}>
+      {header && (
+        <PopoverHeaderStyle>
+          <p className="title">{header.title}</p>
+          {header.reset && <button className="reset">초기화</button>}
+        </PopoverHeaderStyle>
+      )}
+      <div className="popover-content">{children}</div>
+    </PopoverStyle>
+  ) : null;
+};
+
+export default PopOver;

--- a/frontend/tiggle/src/components/atoms/PopOver/PopOverStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/PopOver/PopOverStyle.tsx
@@ -45,7 +45,7 @@ export const PopoverStyle = styled.div`
     flex-shrink: 1;
   }
 
-  transform-origin: top center;
+  transform-origin: top left;
   &.open {
     animation: ${popoverUnfold} 0.3s cubic-bezier(0.29, 1.05, 0.55, 1);
   }

--- a/frontend/tiggle/src/components/atoms/PopOver/PopOverStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/PopOver/PopOverStyle.tsx
@@ -1,0 +1,71 @@
+import styled, { keyframes } from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+const popoverUnfold = keyframes`
+  0% {
+    opacity: 0;
+    transform: scale(75%);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(100%);
+  }
+`;
+
+const popoverFold = keyframes`
+  0% {
+    opacity: 1;
+    transform: scale(100%)
+  }
+  100% {
+    opacity: 0;
+    transform: scale(75%)
+  }
+`;
+
+export const PopoverStyle = styled.div`
+  width: 280px;
+  height: 300px;
+  background-color: ${({ theme }) => theme.color.white.value};
+  border-radius: 16px;
+  box-shadow:
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0px 4px 6px -2px rgba(69, 85, 115, 0.05);
+  overflow-y: hidden;
+
+  display: flex;
+  flex-direction: column;
+
+  position: absolute;
+  top: calc(100% + 8px);
+
+  .popover-content {
+    overflow-y: scroll;
+    flex-shrink: 1;
+  }
+
+  transform-origin: top center;
+  &.open {
+    animation: ${popoverUnfold} 0.3s cubic-bezier(0.29, 1.05, 0.55, 1);
+  }
+
+  &.close {
+    animation: ${popoverFold} 0.15s ease forwards;
+  }
+`;
+
+export const PopoverHeaderStyle = styled.div`
+  padding: 16px;
+  display: flex;
+  justify-content: space-between;
+
+  .title {
+    ${({ theme }) => expandTypography(theme.typography.body.large.bold)}
+  }
+
+  .reset {
+    ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+    color: ${({ theme }) => theme.color.blue[500].value};
+  }
+`;

--- a/frontend/tiggle/src/components/atoms/PopOver/PopOverStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/PopOver/PopOverStyle.tsx
@@ -39,6 +39,7 @@ export const PopoverStyle = styled.div`
 
   position: absolute;
   top: calc(100% + 8px);
+  z-index: 999;
 
   .popover-content {
     overflow-y: scroll;

--- a/frontend/tiggle/src/components/atoms/Upload/Upload.tsx
+++ b/frontend/tiggle/src/components/atoms/Upload/Upload.tsx
@@ -1,10 +1,12 @@
-import { ChangeEvent, forwardRef, useMemo, useState } from "react";
+import { forwardRef, useMemo } from "react";
 import { Plus, Trash2, Upload as UploadIcon } from "react-feather";
 
 import cn from "classnames";
 
 import { UploadStyle } from "@/components/atoms/Upload/UploadStyle";
 import { isDesktop } from "@/styles/util/screen";
+
+import useUpload from "./useUpload";
 
 interface UploadProps extends React.InputHTMLAttributes<HTMLInputElement> {
   onReset: () => void;
@@ -14,32 +16,12 @@ const Upload = forwardRef<HTMLInputElement, UploadProps>(
   ({ name = "upload", onChange, onReset, ...props }, ref) => {
     const desktop = isDesktop();
 
-    const [file, setFile] = useState<File | null>(null);
-    const [imageUrl, setImageUrl] = useState("");
+    const { file, imageUrl, handleUpload, handleReset } = useUpload({
+      onChange,
+      onReset,
+    });
+
     const filled = useMemo(() => file !== null, [file]);
-
-    const encodeFileToImageUrl = (file: File) => {
-      const reader = new FileReader();
-      reader.onload = function () {
-        setImageUrl(reader.result as string);
-      };
-      reader.readAsDataURL(file);
-    };
-
-    const handleUpload = (e: ChangeEvent<HTMLInputElement>) => {
-      onChange(e);
-      const uploadedFile = e.target.files?.[0];
-      if (uploadedFile) {
-        setFile(uploadedFile);
-        encodeFileToImageUrl(uploadedFile);
-      }
-    };
-
-    const handleReset = () => {
-      onReset();
-      setFile(null);
-      setImageUrl("");
-    };
 
     return (
       <UploadStyle className={cn({ filled })}>

--- a/frontend/tiggle/src/components/atoms/Upload/useUpload.ts
+++ b/frontend/tiggle/src/components/atoms/Upload/useUpload.ts
@@ -1,0 +1,48 @@
+import { ChangeEvent, ChangeEventHandler, useState } from "react";
+
+type UseUploadOptions = {
+  onChange: ChangeEventHandler<HTMLInputElement>;
+  onReset: () => void;
+  defaultUrl: string;
+};
+
+const useUpload = ({
+  onChange,
+  onReset,
+  defaultUrl,
+}: Partial<UseUploadOptions>) => {
+  const [file, setFile] = useState<File | null>(null);
+  const [imageUrl, setImageUrl] = useState(defaultUrl ?? "");
+
+  const encodeFileToImageUrl = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = function () {
+      setImageUrl(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleUpload = (e: ChangeEvent<HTMLInputElement>) => {
+    onChange?.(e);
+    const uploadedFile = e.target.files?.[0];
+    if (uploadedFile) {
+      setFile(uploadedFile);
+      encodeFileToImageUrl(uploadedFile);
+    }
+  };
+
+  const handleReset = () => {
+    onReset?.();
+    setFile(null);
+    setImageUrl("");
+  };
+
+  return {
+    file,
+    imageUrl,
+    handleUpload,
+    handleReset,
+  };
+};
+
+export default useUpload;

--- a/frontend/tiggle/src/components/atoms/index.tsx
+++ b/frontend/tiggle/src/components/atoms/index.tsx
@@ -1,3 +1,5 @@
+export { default as BottomSheet } from "./BottomSheet/BottomSheet";
+
 export { default as CTAButton } from "./CTAButton/CTAButton";
 
 export { default as DatePicker } from "./DatePicker/DatePicker";
@@ -11,6 +13,8 @@ export { default as Loading } from "./Loading/Loading";
 export { Menu, MenuItem } from "./Menu/Menu";
 
 export { default as MultiSelect } from "./MultiSelect/MultiSelect";
+
+export { default as PopOver } from "./PopOver/PopOver";
 
 export { default as Select } from "./Select/Select";
 

--- a/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelect.stories.tsx
+++ b/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelect.stories.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+import { StoryObj, Meta } from "@storybook/react";
+
+import FilterSelect from "./FilterSelect";
+
+export default {
+  title: "molecules/FilterSelect",
+  component: FilterSelect,
+} as Meta<typeof FilterSelect>;
+
+type Story = StoryObj<typeof FilterSelect>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "카테고리",
+    options: [
+      { label: "생활비", value: 1 },
+      { label: "생활비", value: 2 },
+      { label: "생활비", value: 3 },
+    ],
+    onChange: () => console.log("select"),
+  },
+  render: args => {
+    const [value, setValue] = useState<Array<number>>([]);
+
+    const handleOnChange = (newValue: Array<number>) => {
+      setValue(newValue);
+    };
+
+    return (
+      <>
+        <FilterSelect {...args} value={value} onChange={handleOnChange} />
+        <div>
+          <p>selected</p>
+          <ul>
+            {value.map(v => (
+              <li>{v}</li>
+            ))}
+          </ul>
+        </div>
+      </>
+    );
+  },
+};

--- a/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelect.tsx
+++ b/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelect.tsx
@@ -1,10 +1,11 @@
 import {
-  RefObject,
+  Ref,
   forwardRef,
   useCallback,
   useEffect,
   useMemo,
   useState,
+  useRef,
 } from "react";
 import { Check, ChevronDown } from "react-feather";
 
@@ -42,10 +43,11 @@ const FilterSelect = forwardRef(
       onChange,
       disabled = false,
     }: FilterSelectProps<ValueType>,
-    ref: RefObject<HTMLDivElement>,
+    ref: Ref<HTMLDivElement>,
   ) => {
     const desktop = isDesktop();
     const mobile = useMemo(() => !desktop, [desktop]);
+    const wrapperRef = useRef<HTMLDivElement | null>(null);
 
     const [isOptionOpen, setIsOptionOpen] = useState(false);
     const [innerValue, setInnerValue] = useState<Array<ValueType>>(value ?? []);
@@ -57,6 +59,7 @@ const FilterSelect = forwardRef(
     const closeOption = useCallback(() => {
       setIsOptionOpen(false);
     }, []);
+    useOnClickOutside(wrapperRef, closeOption);
 
     const updateInnerValue = useCallback(
       (selected: ValueType) => {
@@ -83,55 +86,60 @@ const FilterSelect = forwardRef(
       closeOption();
     };
 
-    useOnClickOutside(ref, closeOption);
-
     useEffect(() => {
       if (!isOptionOpen) {
         // initialized
-        setInnerValue(value);
+        setInnerValue(value ?? []);
       }
     }, [isOptionOpen]);
 
     return (
       <FilterSelectStyle ref={ref}>
-        <FilterSelectButtonStyle onClick={toggleOptionOpen} disabled={disabled}>
-          <p className="placeholder">{placeholder}</p>
-          <ChevronDown />
-        </FilterSelectButtonStyle>
-
-        {mobile && !disabled && (
-          <BottomSheet
-            isOpen={isOptionOpen}
-            header={{ title: `${placeholder} 선택하기`, reset: true }}
-            confirm={{ label: "확인", onClick: confirmBottomSheet }}
-            onClose={closeOption}
+        <div className="wrapper" ref={wrapperRef}>
+          <FilterSelectButtonStyle
+            onClick={toggleOptionOpen}
+            disabled={disabled}
+            type="button"
           >
-            {options.map(option => (
-              <OptionCell
-                key={`option-${option.value}`}
-                option={option}
-                onClick={selectBottomSheetOption}
-                selected={innerValue.includes(option.value)}
-              />
-            ))}
-          </BottomSheet>
-        )}
+            {" "}
+            <p className="placeholder">{placeholder}</p>
+            <ChevronDown />
+          </FilterSelectButtonStyle>
 
-        {desktop && !disabled && (
-          <PopOver
-            isOpen={isOptionOpen}
-            header={{ title: `${placeholder} 선택하기`, reset: true }}
-          >
-            {options.map(option => (
-              <OptionCell
-                key={`option-${option.value}`}
-                option={option}
-                onClick={selectPopoverOption}
-                selected={innerValue.includes(option.value)}
-              />
-            ))}
-          </PopOver>
-        )}
+          {mobile && !disabled && (
+            <BottomSheet
+              isOpen={isOptionOpen}
+              header={{ title: `${placeholder} 선택하기`, reset: true }}
+              confirm={{ label: "확인", onClick: confirmBottomSheet }}
+              onClose={closeOption}
+            >
+              {options.map(option => (
+                <OptionCell
+                  key={`option-${option.value}`}
+                  option={option}
+                  onClick={selectBottomSheetOption}
+                  selected={innerValue.includes(option.value)}
+                />
+              ))}
+            </BottomSheet>
+          )}
+
+          {desktop && !disabled && (
+            <PopOver
+              isOpen={isOptionOpen}
+              header={{ title: `${placeholder} 선택하기`, reset: true }}
+            >
+              {options.map(option => (
+                <OptionCell
+                  key={`option-${option.value}`}
+                  option={option}
+                  onClick={selectPopoverOption}
+                  selected={innerValue.includes(option.value)}
+                />
+              ))}
+            </PopOver>
+          )}
+        </div>
       </FilterSelectStyle>
     );
   },

--- a/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelect.tsx
+++ b/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelect.tsx
@@ -1,0 +1,163 @@
+import {
+  RefObject,
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { Check, ChevronDown } from "react-feather";
+
+import cn from "classnames";
+
+import { BottomSheet, PopOver } from "@/components/atoms";
+import useOnClickOutside from "@/hooks/useOnClickOutside";
+import { isDesktop } from "@/styles/util/screen";
+
+import {
+  FilterSelectButtonStyle,
+  FilterSelectStyle,
+  OptionCellStyle,
+} from "./FilterSelectStyle";
+
+interface OptionType<ValueType = string | number | null> {
+  label: React.ReactNode;
+  value: ValueType;
+}
+
+interface FilterSelectProps<ValueType> {
+  options: Array<OptionType<ValueType>>;
+  value?: Array<ValueType>;
+  onChange?: (value: ValueType[]) => void;
+  placeholder: string;
+  disabled?: boolean;
+}
+
+const FilterSelect = forwardRef(
+  <ValueType extends OptionType["value"]>(
+    {
+      placeholder,
+      value,
+      options,
+      onChange,
+      disabled = false,
+    }: FilterSelectProps<ValueType>,
+    ref: RefObject<HTMLDivElement>,
+  ) => {
+    const desktop = isDesktop();
+    const mobile = useMemo(() => !desktop, [desktop]);
+
+    const [isOptionOpen, setIsOptionOpen] = useState(false);
+    const [innerValue, setInnerValue] = useState<Array<ValueType>>(value ?? []);
+
+    const toggleOptionOpen = useCallback(() => {
+      setIsOptionOpen(!isOptionOpen);
+    }, [isOptionOpen]);
+
+    const closeOption = useCallback(() => {
+      setIsOptionOpen(false);
+    }, []);
+
+    const updateInnerValue = useCallback(
+      (selected: ValueType) => {
+        const newInnerValue = innerValue.includes(selected)
+          ? innerValue.filter(v => v !== selected)
+          : [...innerValue, selected];
+        setInnerValue(newInnerValue);
+        return newInnerValue;
+      },
+      [innerValue],
+    );
+
+    const selectPopoverOption = (selected: ValueType) => {
+      const newInnerValue = updateInnerValue(selected);
+      onChange?.(newInnerValue);
+    };
+
+    const selectBottomSheetOption = (selected: ValueType) => {
+      updateInnerValue(selected);
+    };
+
+    const confirmBottomSheet = () => {
+      onChange?.(innerValue);
+      closeOption();
+    };
+
+    useOnClickOutside(ref, closeOption);
+
+    useEffect(() => {
+      if (!isOptionOpen) {
+        // initialized
+        setInnerValue(value);
+      }
+    }, [isOptionOpen]);
+
+    return (
+      <FilterSelectStyle ref={ref}>
+        <FilterSelectButtonStyle onClick={toggleOptionOpen} disabled={disabled}>
+          <p className="placeholder">{placeholder}</p>
+          <ChevronDown />
+        </FilterSelectButtonStyle>
+
+        {mobile && !disabled && (
+          <BottomSheet
+            isOpen={isOptionOpen}
+            header={{ title: `${placeholder} 선택하기`, reset: true }}
+            confirm={{ label: "확인", onClick: confirmBottomSheet }}
+            onClose={closeOption}
+          >
+            {options.map(option => (
+              <OptionCell
+                key={`option-${option.value}`}
+                option={option}
+                onClick={selectBottomSheetOption}
+                selected={innerValue.includes(option.value)}
+              />
+            ))}
+          </BottomSheet>
+        )}
+
+        {desktop && !disabled && (
+          <PopOver
+            isOpen={isOptionOpen}
+            header={{ title: `${placeholder} 선택하기`, reset: true }}
+          >
+            {options.map(option => (
+              <OptionCell
+                key={`option-${option.value}`}
+                option={option}
+                onClick={selectPopoverOption}
+                selected={innerValue.includes(option.value)}
+              />
+            ))}
+          </PopOver>
+        )}
+      </FilterSelectStyle>
+    );
+  },
+);
+
+export default FilterSelect;
+
+interface OptionCellProps<ValueType> {
+  option: OptionType<ValueType>;
+  onClick: (value: ValueType) => void;
+  selected: boolean;
+}
+
+const OptionCell = <ValueType extends OptionType["value"]>({
+  option: { label, value },
+  onClick,
+  selected,
+}: OptionCellProps<ValueType>) => {
+  return (
+    <OptionCellStyle
+      id={`option-${value}`}
+      className={cn({ selected })}
+      onClick={() => onClick(value)}
+    >
+      <p className="popover-option-label">{label}</p>
+      {selected && <Check size={16} />}
+    </OptionCellStyle>
+  );
+};

--- a/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelectStyle.tsx
+++ b/frontend/tiggle/src/components/molecules/FilterSelect/FilterSelectStyle.tsx
@@ -1,0 +1,63 @@
+import styled from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+export const FilterSelectStyle = styled.div`
+  width: fit-content;
+  position: relative;
+`;
+
+export const FilterSelectButtonStyle = styled.button`
+  width: fit-content;
+  padding: 8px 12px;
+  border-radius: 12px;
+  background-color: ${({ theme }) => theme.color.white.value};
+  color: ${({ theme }) => theme.color.blue[500].value};
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  .placeholder {
+    ${({ theme }) => expandTypography(theme.typography.body.medium.regular)}
+  }
+
+  > svg {
+    width: 20px;
+    height: 20px;
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.color.bluishGray[100].value};
+    color: ${({ theme }) => theme.color.bluishGray[500].value};
+    cursor: not-allowed;
+  }
+`;
+
+export const OptionCellStyle = styled.li`
+  width: 100%;
+  padding: 16px;
+  ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+  color: ${({ theme }) => theme.color.bluishGray[700].value};
+
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .popover-option-label {
+    flex-grow: 1;
+  }
+
+  &:not(:last-child) {
+    border-bottom: 1px solid ${({ theme }) => theme.color.bluishGray[200].value};
+  }
+
+  &.selected {
+    background-color: ${({ theme }) => theme.color.blue[50].value};
+    color: ${({ theme }) => theme.color.blue[600].value};
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    padding: 12px 16px;
+  }
+`;

--- a/frontend/tiggle/src/hooks/useAuth.tsx
+++ b/frontend/tiggle/src/hooks/useAuth.tsx
@@ -18,6 +18,7 @@ export default function useAuth() {
   const navigate = useNavigate();
   const location = useLocation();
   const { getCookie, removeCookie } = useCookie();
+  const token = getCookie("Authorization");
 
   const {
     data: profile,
@@ -27,10 +28,11 @@ export default function useAuth() {
     memberKeys.detail("me"),
     async () =>
       MemberApiControllerService.getMe(
-        getCookie("Authorization") ? TEMP_USER_ID : undefined, // TODO: 프로필조회 api 수정 후 삭제
+        token ? TEMP_USER_ID : undefined, // TODO: 프로필조회 api 수정 후 삭제
       ),
     {
       staleTime: 1000 * 60 * 30,
+      enabled: !!token,
     },
   );
 
@@ -45,8 +47,8 @@ export default function useAuth() {
   };
 
   const logOut = () => {
-    queryClient.invalidateQueries(memberKeys.detail("me"));
     removeCookie("Authorization");
+    queryClient.invalidateQueries(memberKeys.detail("me"));
     navigate("/login");
   };
 

--- a/frontend/tiggle/src/hooks/useMessage/MessageProvider.tsx
+++ b/frontend/tiggle/src/hooks/useMessage/MessageProvider.tsx
@@ -1,0 +1,28 @@
+import { PropsWithChildren, createContext, useMemo } from "react";
+
+import { message } from "antd";
+import { MessageInstance } from "antd/lib/message/interface";
+
+interface MessageState {
+  api: MessageInstance;
+}
+
+export const MessageContext = createContext<MessageState>({ api: undefined });
+if (process.env.NODE_ENV !== "production") {
+  MessageContext.displayName = "MessageContext";
+}
+
+const MessageProvider = ({ children }: PropsWithChildren) => {
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const context = useMemo(() => ({ api: messageApi }), [messageApi]);
+
+  return (
+    <MessageContext.Provider value={context}>
+      {contextHolder}
+      {children}
+    </MessageContext.Provider>
+  );
+};
+
+export default MessageProvider;

--- a/frontend/tiggle/src/hooks/useMessage/index.ts
+++ b/frontend/tiggle/src/hooks/useMessage/index.ts
@@ -1,0 +1,10 @@
+import { useContext } from "react";
+
+import { MessageContext } from "./MessageProvider";
+
+const useMessage = () => {
+  const context = useContext(MessageContext);
+  return context.api;
+};
+
+export default useMessage;

--- a/frontend/tiggle/src/index.tsx
+++ b/frontend/tiggle/src/index.tsx
@@ -11,6 +11,7 @@ import { PersistGate } from "redux-persist/integration/react";
 import { ThemeProvider } from "styled-components";
 
 import router from "@/Router";
+import MessageProvider from "@/hooks/useMessage/MessageProvider";
 import queryClient from "@/query/queryClient";
 import { store, persistedStore } from "@/store";
 import { GlobalStyle } from "@/styles/config/GlobalStyle";
@@ -44,6 +45,7 @@ root.render(
         <PersistGate persistor={persistedStore} />,
         <ThemeProvider theme={{ ...theme, mq }} />,
         <ConfigProvider theme={antTheme} />,
+        <MessageProvider />,
       ]}
     >
       {process.env.NODE_ENV === "development" && <ReactQueryDevtools />}

--- a/frontend/tiggle/src/pages/CreatePage/index.tsx
+++ b/frontend/tiggle/src/pages/CreatePage/index.tsx
@@ -9,11 +9,11 @@ import {
 import { QueryClient, useMutation } from "@tanstack/react-query";
 import dayjs from "dayjs";
 
+import useMessage from "@/hooks/useMessage";
 import CreateForm, {
   FormInputs,
 } from "@/pages/CreatePage/CreateForm/CreateForm";
 import { CreatePageStyle } from "@/pages/CreatePage/CreatePageStyle";
-import { useMessage } from "@/templates/GeneralTemplate";
 import { TxType } from "@/types";
 import { convertTxTypeToWord } from "@/utils/txType";
 import withAuth, { AuthProps } from "@/utils/withAuth";
@@ -37,7 +37,7 @@ interface CreatePageProps extends AuthProps {
 
 const CreatePage = ({ type }: CreatePageProps) => {
   const navigate = useNavigate();
-  const { messageApi } = useMessage();
+  const messageApi = useMessage();
   const parentId = Number(useParams().id);
 
   const initialData = useLoaderData() as Awaited<

--- a/frontend/tiggle/src/pages/CreatePage/request.ts
+++ b/frontend/tiggle/src/pages/CreatePage/request.ts
@@ -1,9 +1,8 @@
-import axios from "axios";
-
 import {
   TransactionApiControllerService,
   TransactionRespDto,
 } from "@/generated";
+import { getAxiosInstance } from "@/query/openapi-request";
 
 export type TransactionFormData = Parameters<
   typeof TransactionApiControllerService.createTransaction
@@ -17,7 +16,7 @@ export const createTransaction = async ({
   formData.append("dto", JSON.stringify(dto));
   formData.append("multipartFile", multipartFile);
 
-  return axios
+  return getAxiosInstance()
     .post<TransactionRespDto>("/api/v1/transaction", formData, {
       baseURL: process.env.REACT_APP_API_URL,
       headers: {

--- a/frontend/tiggle/src/pages/DetailPage/CommentCell/CommentCell.tsx
+++ b/frontend/tiggle/src/pages/DetailPage/CommentCell/CommentCell.tsx
@@ -8,6 +8,7 @@ import { Avatar } from "antd";
 import CTAButton from "@/components/atoms/CTAButton/CTAButton";
 import TextArea from "@/components/atoms/TextArea/TextArea";
 import { CommentApiService, CommentRespDto } from "@/generated";
+import useMessage from "@/hooks/useMessage";
 import {
   CommentCellStyle,
   CommentRepliesStyle,
@@ -17,7 +18,6 @@ import {
 } from "@/pages/DetailPage/CommentCell/CommentCellStyle";
 import queryClient from "@/query/queryClient";
 import { RootState } from "@/store";
-import { useMessage } from "@/templates/GeneralTemplate";
 import { calculateDateTimeDiff } from "@/utils/date";
 import { convertTxTypeToColor } from "@/utils/txType";
 
@@ -43,7 +43,7 @@ export default function CommentCell({
   sender,
   receiverId,
 }: CommentCellProps) {
-  const { messageApi } = useMessage();
+  const messageApi = useMessage();
   const [replyOpen, setReplyOpen] = useState(false);
 
   const toggleReplySection = () => {

--- a/frontend/tiggle/src/pages/DetailPage/CommentForm/CommentForm.tsx
+++ b/frontend/tiggle/src/pages/DetailPage/CommentForm/CommentForm.tsx
@@ -3,11 +3,12 @@ import { SubmitHandler, useForm, Controller } from "react-hook-form";
 import { useSelector } from "react-redux";
 
 import { useMutation } from "@tanstack/react-query";
-import { Avatar, message } from "antd";
+import { Avatar } from "antd";
 
 import CTAButton from "@/components/atoms/CTAButton/CTAButton";
 import { CommentApiService } from "@/generated";
 import useAuth from "@/hooks/useAuth";
+import useMessage from "@/hooks/useMessage";
 import { CommentSenderStyle } from "@/pages/DetailPage/CommentCell/CommentCellStyle";
 import { CommentFormStyle } from "@/pages/DetailPage/CommentForm/CommentFormStyle";
 import queryClient from "@/query/queryClient";
@@ -32,7 +33,7 @@ export default function CommentForm({
 }: CommentFormProps) {
   const { isLogin, profile, checkIsLogin } = useAuth();
   const txType = useSelector((state: RootState) => state.detailPage.txType);
-  const [messageApi, contextHolder] = message.useMessage();
+  const messageApi = useMessage();
   const {
     control,
     handleSubmit,
@@ -61,54 +62,51 @@ export default function CommentForm({
   };
 
   return (
-    <>
-      {contextHolder}
-      <CommentFormStyle
-        {...props}
-        onSubmit={handleSubmit(onSubmit)}
-        className={txType}
-      >
-        <CommentSenderStyle>
-          {isLogin && profile ? (
-            <>
-              <Avatar size={32} src={profile.profileUrl} />
-              <p className="name">{profile.nickname}</p>
-            </>
-          ) : (
-            <>
-              <Avatar size={32} />
-              <p className="name">사용자</p>
-            </>
-          )}
-        </CommentSenderStyle>
+    <CommentFormStyle
+      {...props}
+      onSubmit={handleSubmit(onSubmit)}
+      className={txType}
+    >
+      <CommentSenderStyle>
+        {isLogin && profile ? (
+          <>
+            <Avatar size={32} src={profile.profileUrl} />
+            <p className="name">{profile.nickname}</p>
+          </>
+        ) : (
+          <>
+            <Avatar size={32} />
+            <p className="name">사용자</p>
+          </>
+        )}
+      </CommentSenderStyle>
 
-        <Controller
-          name="comment"
-          control={control}
-          rules={{ required: true }}
-          render={({ field }) => (
-            <textarea
-              className="comment"
-              placeholder="댓글 남기기"
-              rows={2}
-              onFocus={() => checkIsLogin()}
-              {...field}
-            />
-          )}
-        />
+      <Controller
+        name="comment"
+        control={control}
+        rules={{ required: true }}
+        render={({ field }) => (
+          <textarea
+            className="comment"
+            placeholder="댓글 남기기"
+            rows={2}
+            onFocus={() => checkIsLogin()}
+            {...field}
+          />
+        )}
+      />
 
-        <div className="button-wrapper">
-          <CTAButton
-            size="md"
-            variant="secondary"
-            color={convertTxTypeToColor(txType)}
-            type="submit"
-            disabled={!isValid}
-          >
-            댓글 등록
-          </CTAButton>
-        </div>
-      </CommentFormStyle>
-    </>
+      <div className="button-wrapper">
+        <CTAButton
+          size="md"
+          variant="secondary"
+          color={convertTxTypeToColor(txType)}
+          type="submit"
+          disabled={!isValid}
+        >
+          댓글 등록
+        </CTAButton>
+      </div>
+    </CommentFormStyle>
   );
 }

--- a/frontend/tiggle/src/pages/MainPage/query.ts
+++ b/frontend/tiggle/src/pages/MainPage/query.ts
@@ -1,8 +1,10 @@
-import { TransactionApiControllerService } from "@/generated";
-import { transactionKeys } from "@/query/queryKeys";
 import { useQuery } from "@tanstack/react-query";
 
-export const useAllTransactionsQuery = () => useQuery({
-  queryKey: transactionKeys.lists(),
-  queryFn: () => TransactionApiControllerService.getAllTransaction(),
-});
+import { TransactionApiControllerService } from "@/generated";
+import { transactionKeys } from "@/query/queryKeys";
+
+export const useAllTransactionsQuery = () =>
+  useQuery({
+    queryKey: transactionKeys.lists(),
+    queryFn: () => TransactionApiControllerService.getAllTransaction(),
+  });

--- a/frontend/tiggle/src/pages/MyPage/index.tsx
+++ b/frontend/tiggle/src/pages/MyPage/index.tsx
@@ -26,64 +26,70 @@ const MyPage = ({ profile }: MyPageProps) => {
   );
 
   return (
-    <>
-      <MypageStyle>
-        {!isLoginLoading && (
-          <div className="user-info">
-            <div className="user">
-              {profile.profileUrl ? (
-                <img
-                  className="user-profile"
-                  alt="user-profile"
-                  src={profile.profileUrl}
-                />
-              ) : (
-                <Avatar />
-              )}
-            </div>
-            <div className="user-greeting">
-              <p>
-                <span className="user-name">{profile.nickname}</span>님,
-              </p>
-              <p>안녕하세요</p>
-            </div>
-            <a href="/mypage/profile">
-              <button className="profile-modify-button">프로필 수정</button>
-            </a>
+    <MypageStyle>
+      {!isLoginLoading && (
+        <div className="user-info">
+          <div className="user">
+            {profile.profileUrl ? (
+              <img
+                className="user-profile"
+                alt="user-profile"
+                src={profile.profileUrl}
+              />
+            ) : (
+              <Avatar />
+            )}
           </div>
-        )}
-        {!isTxLoading && !isTxError && (
-          <div className="user-transaction">
-            <p className="transaction-title">내 거래 기록</p>
-            <div className="transaction-cells">
-              {sortArray.slice(0, 3).map(props => (
-                <MyTransactionCell key={`tx-cell-${props.id}`} {...props} />
-              ))}
+          <div className="user-greeting">
+            <p>
+              <span className="user-name">{profile.nickname}</span>님,
+            </p>
+            <p>안녕하세요</p>
+          </div>
+          <a href="/mypage/profile">
+            <button className="profile-modify-button">프로필 수정</button>
+          </a>
+        </div>
+      )}
+      {!isTxLoading && !isTxError && (
+        <div className="user-transaction">
+          <p className="transaction-title">내 거래 기록</p>
+          <div className="transaction-cells">
+            {sortArray.slice(0, 3).map(props => (
+              <MyTransactionCell key={`tx-cell-${props.id}`} {...props} />
+            ))}
+            <a href="/mypage/my-transactions">
               <div className="transaction-cell">
                 <button>내 거래기록 더 보기</button>
               </div>
-            </div>
+            </a>
           </div>
-        )}
-        <div className="user-setting">
-          <p className="setting-title">설정</p>
-          <div className="setting-cells">
+        </div>
+      )}
+      <div className="user-setting">
+        <p className="setting-title">설정</p>
+        <div className="setting-cells">
+          <a href="/mypage/setting/asset">
             <button className="setting-cell">
-              <span>자산 항목 관리</span> <ChevronRight />
+              <span>자산 관리</span> <ChevronRight />
             </button>
+          </a>
+          <a href="/mypage/setting/outcome-category">
             <button className="setting-cell">
               <span>지출 카테고리 관리</span> <ChevronRight />
             </button>
+          </a>
+          <a href="/mypage/setting/income-category">
             <button className="setting-cell">
               <span>수입 카테고리 관리</span> <ChevronRight />
             </button>
-          </div>
+          </a>
         </div>
-        <button onClick={() => logOut()} className="logout-button">
-          로그아웃
-        </button>
-      </MypageStyle>
-    </>
+      </div>
+      <button onClick={() => logOut()} className="logout-button">
+        로그아웃
+      </button>
+    </MypageStyle>
   );
 };
 

--- a/frontend/tiggle/src/pages/MyProfilePage/MyDetailPageCommonStyle.tsx
+++ b/frontend/tiggle/src/pages/MyProfilePage/MyDetailPageCommonStyle.tsx
@@ -1,0 +1,31 @@
+import styled from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+export const MypageDetailPageStyle = styled.div`
+  width: 100%;
+  padding: 24px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+
+  .page-title {
+    margin-bottom: 48px;
+    color: ${({ theme }) => theme.color.bluishGray[800].value};
+    ${({ theme }) => expandTypography(theme.typography.title.medium.bold)}
+    text-align: left;
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    width: 480px;
+    margin: 0 auto;
+    padding: 32px 0;
+
+    .page-title {
+      margin-bottom: 64px;
+      ${({ theme }) => expandTypography(theme.typography.title.large.bold)}
+      text-align: center;
+    }
+  }
+`;

--- a/frontend/tiggle/src/pages/MyProfilePage/MyProfilePageStyle.tsx
+++ b/frontend/tiggle/src/pages/MyProfilePage/MyProfilePageStyle.tsx
@@ -1,0 +1,123 @@
+import styled from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+export const ProfileImageSectionStyle = styled.div`
+  margin-bottom: 48px;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+
+  .profile-avatar {
+    position: relative;
+
+    .ant-avatar {
+      background-color: ${({ theme }) => theme.color.bluishGray[300].value};
+      background-image: url("/assets/user-placeholder.png");
+      background-size: cover;
+    }
+  }
+
+  .profile-edit {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.color.bluishGray[200].value};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.color.bluishGray[50].value};
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    position: absolute;
+    bottom: 4px;
+    right: -4px;
+    cursor: pointer;
+
+    > svg {
+      width: 20px;
+      height: 20px;
+      color: ${({ theme }) => theme.color.bluishGray[600].value};
+    }
+
+    &:hover {
+      background-color: ${({ theme }) => theme.color.bluishGray[300].value};
+    }
+  }
+
+  input[type="file"] {
+    position: absolute;
+    width: 0;
+    height: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  .profile-delete-btn {
+    width: 100px;
+    padding: 8px 0;
+    border-radius: 8px;
+
+    ${({ theme }) => expandTypography(theme.typography.body.small.medium)}
+    color: ${({ theme }) => theme.color.bluishGray[600].value};
+    background-color: ${({ theme }) => theme.color.bluishGray[100].value};
+
+    &:hover {
+      background-color: ${({ theme }) => theme.color.bluishGray[200].value};
+    }
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    margin-bottom: 64px;
+
+    .profile-edit-btn {
+      width: 42px;
+      height: 42px;
+
+      > svg {
+        width: 24px;
+        height: 24px;
+        color: ${({ theme }) => theme.color.bluishGray[600].value};
+      }
+    }
+
+    .profile-delete-btn {
+      width: 120px;
+      ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+    }
+  }
+`;
+
+export const ProfileFormItemStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 24px;
+
+  > label {
+    ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+    color: ${({ theme }) => theme.color.bluishGray[600].value}
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    margin-bottom: 32px;
+    > label {
+      ${({ theme }) => expandTypography(theme.typography.body.large.medium)}
+    }
+  }
+`;
+
+export const ProfileFormControllerStyle = styled.div`
+  padding-top: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+
+  ${({ theme }) => theme.mq.desktop} {
+    padding-top: 32px;
+    gap: 16px;
+  }
+`;

--- a/frontend/tiggle/src/pages/MyProfilePage/controller.ts
+++ b/frontend/tiggle/src/pages/MyProfilePage/controller.ts
@@ -1,5 +1,5 @@
 import { useForm } from "react-hook-form";
-import { useLoaderData } from "react-router-dom";
+import { useLoaderData, useNavigate } from "react-router-dom";
 
 import { QueryClient, useMutation, useQuery } from "@tanstack/react-query";
 import dayjs from "dayjs";
@@ -24,6 +24,7 @@ export const loader = (queryClient: QueryClient) => () =>
 
 export const useProfilePage = () => {
   const messageApi = useMessage();
+  const navigate = useNavigate();
 
   const initialData = useLoaderData() as Awaited<
     ReturnType<ReturnType<typeof loader>>
@@ -98,6 +99,10 @@ export const useProfilePage = () => {
     },
   );
 
+  const handleCancel = () => {
+    navigate(-1);
+  };
+
   return {
     control,
     profileUrlRegister,
@@ -106,5 +111,6 @@ export const useProfilePage = () => {
     handleSubmit,
     handleUpload,
     handleResetImage: handleReset,
+    handleCancel,
   };
 };

--- a/frontend/tiggle/src/pages/MyProfilePage/controller.ts
+++ b/frontend/tiggle/src/pages/MyProfilePage/controller.ts
@@ -1,0 +1,110 @@
+import { useForm } from "react-hook-form";
+import { useLoaderData } from "react-router-dom";
+
+import { QueryClient, useMutation, useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
+
+import useUpload from "@/components/atoms/Upload/useUpload";
+import { MemberApiControllerService } from "@/generated";
+import { useMessage } from "@/templates/GeneralTemplate";
+
+import { MemberFormData, updateProfile } from "./request";
+
+import type { ProfileInputs } from "./types";
+
+const TEMP_MEMBER_ID = 4;
+
+const profileQuery = () => ({
+  queryKey: ["profile", "me"],
+  queryFn: async () => MemberApiControllerService.getMe(TEMP_MEMBER_ID),
+});
+
+export const loader = (queryClient: QueryClient) => () =>
+  queryClient.ensureQueryData(profileQuery());
+
+export const useProfilePage = () => {
+  const { messageApi } = useMessage();
+
+  const initialData = useLoaderData() as Awaited<
+    ReturnType<ReturnType<typeof loader>>
+  >;
+  const { data: profileData, refetch: refetchProfileData } = useQuery({
+    ...profileQuery(),
+    initialData,
+  });
+
+  const { mutate } = useMutation(updateProfile);
+
+  const {
+    control,
+    register,
+    reset,
+    resetField,
+    handleSubmit: _handleSubmit,
+    formState: { isDirty: _isDirty, dirtyFields },
+  } = useForm<ProfileInputs>({
+    defaultValues: {
+      nickname: profileData.nickname,
+      email: profileData.email,
+      birth: dayjs(profileData.birth),
+    },
+  });
+  const profileUrlRegister = register("profileUrl");
+  const isDirty = _isDirty && Object.keys(dirtyFields).length > 0;
+
+  const { imageUrl, handleUpload, handleReset } = useUpload({
+    onReset: () => resetField("profileUrl"),
+    defaultUrl: profileData?.profileUrl,
+  });
+
+  const handleSubmit = _handleSubmit(
+    ({ nickname, birth, email, profileUrl }: ProfileInputs) => {
+      if (Object.keys(dirtyFields).length === 0) {
+        return;
+      }
+
+      const formData: MemberFormData = {
+        // TODO: xMemberId 삭제
+        xMemberId: TEMP_MEMBER_ID,
+        memberDto: {
+          ...(dirtyFields["nickname"] && { nickname }),
+          ...(dirtyFields["email"] && { email }),
+          ...(dirtyFields["birth"] && { birth: dayjs(birth).toISOString() }),
+        },
+        multipartFile: dirtyFields["profileUrl"] && profileUrl[0],
+      };
+
+      mutate(formData, {
+        onSuccess: () => {
+          messageApi.open({
+            type: "success",
+            content: "프로필 수정이 완료되었습니다.",
+          });
+          refetchProfileData().then(({ data }) => {
+            reset({
+              nickname: data.nickname,
+              email: data.email,
+              birth: dayjs(data.birth),
+            });
+          });
+        },
+        onError: () => {
+          messageApi.open({
+            type: "error",
+            content: "프로필 수정에 실패했습니다.",
+          });
+        },
+      });
+    },
+  );
+
+  return {
+    control,
+    profileUrlRegister,
+    isDirty,
+    profileUrl: imageUrl,
+    handleSubmit,
+    handleUpload,
+    handleResetImage: handleReset,
+  };
+};

--- a/frontend/tiggle/src/pages/MyProfilePage/controller.ts
+++ b/frontend/tiggle/src/pages/MyProfilePage/controller.ts
@@ -6,7 +6,7 @@ import dayjs from "dayjs";
 
 import useUpload from "@/components/atoms/Upload/useUpload";
 import { MemberApiControllerService } from "@/generated";
-import { useMessage } from "@/templates/GeneralTemplate";
+import useMessage from "@/hooks/useMessage";
 
 import { MemberFormData, updateProfile } from "./request";
 
@@ -23,7 +23,7 @@ export const loader = (queryClient: QueryClient) => () =>
   queryClient.ensureQueryData(profileQuery());
 
 export const useProfilePage = () => {
-  const { messageApi } = useMessage();
+  const messageApi = useMessage();
 
   const initialData = useLoaderData() as Awaited<
     ReturnType<ReturnType<typeof loader>>

--- a/frontend/tiggle/src/pages/MyProfilePage/index.tsx
+++ b/frontend/tiggle/src/pages/MyProfilePage/index.tsx
@@ -23,6 +23,7 @@ const MyProfilePage = () => {
     handleSubmit,
     handleUpload,
     handleResetImage,
+    handleCancel,
   } = useProfilePage();
 
   return (
@@ -90,10 +91,7 @@ const MyProfilePage = () => {
             <CTAButton type="submit" size="lg" fullWidth disabled={!isDirty}>
               수정하기
             </CTAButton>
-            <TextButton
-              color="bluishGray500"
-              onClick={() => console.log("cancel")}
-            >
+            <TextButton color="bluishGray500" onClick={handleCancel}>
               취소
             </TextButton>
           </ProfileFormControllerStyle>

--- a/frontend/tiggle/src/pages/MyProfilePage/index.tsx
+++ b/frontend/tiggle/src/pages/MyProfilePage/index.tsx
@@ -1,0 +1,106 @@
+import { Camera } from "react-feather";
+import { Controller } from "react-hook-form";
+
+import { Avatar } from "antd";
+
+import { CTAButton, DatePicker, Input, TextButton } from "@/components/atoms";
+import withAuth from "@/utils/withAuth";
+
+import { MypageDetailPageStyle } from "./MyDetailPageCommonStyle";
+import {
+  ProfileImageSectionStyle,
+  ProfileFormItemStyle,
+  ProfileFormControllerStyle,
+} from "./MyProfilePageStyle";
+import { useProfilePage } from "./controller";
+
+const MyProfilePage = () => {
+  const {
+    control,
+    profileUrlRegister,
+    isDirty,
+    profileUrl,
+    handleSubmit,
+    handleUpload,
+    handleResetImage,
+  } = useProfilePage();
+
+  return (
+    <MypageDetailPageStyle>
+      <p className="page-title">내 프로필 수정</p>
+
+      <form encType="multipart/form-data" onSubmit={handleSubmit}>
+        <ProfileImageSectionStyle>
+          <div className="profile-avatar">
+            <Avatar size={{ md: 120, lg: 160 }} src={profileUrl} />
+            <label className="profile-edit">
+              <input
+                type="file"
+                accept="image/*"
+                {...profileUrlRegister}
+                onChange={e => {
+                  handleUpload(e);
+                  profileUrlRegister.onChange(e);
+                }}
+              />
+              <Camera strokeWidth={2} />
+            </label>
+          </div>
+
+          <button className="profile-delete-btn" onClick={handleResetImage}>
+            이미지 삭제
+          </button>
+        </ProfileImageSectionStyle>
+
+        <div className="profile-inputs">
+          <ProfileFormItemStyle>
+            <label>닉네임</label>
+            <Controller
+              name="nickname"
+              control={control}
+              render={({ field }) => (
+                <Input placeholder="닉네임을 입력하세요" {...field} />
+              )}
+            />
+          </ProfileFormItemStyle>
+
+          <ProfileFormItemStyle>
+            <label>생년월일</label>
+            <Controller
+              name="birth"
+              control={control}
+              render={({ field }) => (
+                <DatePicker placeholder="생년월일을 입력하세요" {...field} />
+              )}
+            />
+          </ProfileFormItemStyle>
+
+          <ProfileFormItemStyle>
+            <label>이메일</label>
+            <Controller
+              name="email"
+              control={control}
+              render={({ field }) => (
+                <Input placeholder="이메일을 입력하세요" {...field} />
+              )}
+            />
+          </ProfileFormItemStyle>
+
+          <ProfileFormControllerStyle>
+            <CTAButton type="submit" size="lg" fullWidth disabled={!isDirty}>
+              수정하기
+            </CTAButton>
+            <TextButton
+              color="bluishGray500"
+              onClick={() => console.log("cancel")}
+            >
+              취소
+            </TextButton>
+          </ProfileFormControllerStyle>
+        </div>
+      </form>
+    </MypageDetailPageStyle>
+  );
+};
+
+export default withAuth(MyProfilePage);

--- a/frontend/tiggle/src/pages/MyProfilePage/request.ts
+++ b/frontend/tiggle/src/pages/MyProfilePage/request.ts
@@ -1,0 +1,25 @@
+import { MemberApiControllerService, MemberDto } from "@/generated";
+import { getAxiosInstance } from "@/query/openapi-request";
+
+export type MemberFormData = Parameters<
+  typeof MemberApiControllerService.updateMe
+>[1] & { xMemberId: number };
+
+export const updateProfile = async ({
+  xMemberId,
+  memberDto,
+  multipartFile,
+}: MemberFormData) => {
+  const formData = new FormData();
+  formData.append("memberDto", JSON.stringify(memberDto));
+  formData.append("multipartFile", multipartFile);
+
+  return getAxiosInstance()
+    .put<MemberDto>("/api/v1/member/me", formData, {
+      headers: {
+        "x-member-id": xMemberId,
+        "Content-Type": "multipart/form-data",
+      },
+    })
+    .then(({ data }) => data);
+};

--- a/frontend/tiggle/src/pages/MyProfilePage/types.ts
+++ b/frontend/tiggle/src/pages/MyProfilePage/types.ts
@@ -1,0 +1,10 @@
+import { Dayjs } from "dayjs";
+
+import { MemberDto } from "@/generated";
+
+export type ProfileInputs = Partial<
+  Omit<MemberDto, "id" | "birth" | "profileUrl"> & {
+    birth: Dayjs;
+    profileUrl: File[];
+  }
+>;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/DateFilter/DateFilter.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/DateFilter/DateFilter.tsx
@@ -1,0 +1,56 @@
+import {
+  ForwardedRef,
+  forwardRef,
+  useCallback,
+  useMemo,
+  useState,
+} from "react";
+import { ChevronLeft, ChevronRight } from "react-feather";
+import { ControllerRenderProps } from "react-hook-form";
+
+import dayjs, { Dayjs } from "dayjs";
+
+import { DateFilterStyle } from "./DateFilterStyle";
+
+interface DateFilterProps extends Omit<ControllerRenderProps, "ref"> {}
+
+const DateFilter = forwardRef(
+  ({ value, onChange }: DateFilterProps, ref: ForwardedRef<HTMLDivElement>) => {
+    const [date, setDate] = useState<Dayjs>(value);
+
+    const isNextDisabled = useMemo(
+      () => dayjs(date).isSame(dayjs(), "month"),
+      [date],
+    );
+
+    const dateMoveHandler = useCallback(
+      (direction: "prev" | "next") => () => {
+        const newDate =
+          direction === "prev"
+            ? dayjs(date).subtract(1, "month")
+            : dayjs(date).add(1, "month");
+        setDate(newDate);
+        onChange(newDate);
+      },
+      [date, onChange],
+    );
+
+    return (
+      <DateFilterStyle className="filter-item" ref={ref}>
+        <button className="move-btn" onClick={dateMoveHandler("prev")}>
+          <ChevronLeft />
+        </button>
+        <p className="title">{dayjs(date).format("YYYY년 MM월")}</p>
+        <button
+          className="move-btn"
+          onClick={dateMoveHandler("next")}
+          disabled={isNextDisabled}
+        >
+          <ChevronRight />
+        </button>
+      </DateFilterStyle>
+    );
+  },
+);
+
+export default DateFilter;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/DateFilter/DateFilterStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/DateFilter/DateFilterStyle.tsx
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+export const DateFilterStyle = styled.div`
+  padding: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .title {
+    flex-grow: 1;
+    text-align: center;
+    ${({ theme }) => expandTypography(theme.typography.body.large.bold)}
+  }
+
+  .move-btn {
+    width: 28px;
+    height: 28px;
+    color: ${({ theme }) => theme.color.bluishGray[600].value};
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    > svg {
+      width: 20px;
+      height: 20px;
+    }
+
+    &:disabled {
+      color: ${({ theme }) => theme.color.bluishGray[400].value};
+    }
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    padding: 12px;
+
+    .title {
+      ${({ theme }) => expandTypography(theme.typography.title.small2x.bold)}
+    }
+
+    .move-btn {
+      width: 32px;
+      height: 32px;
+      > svg {
+        width: 24px;
+        height: 24px;
+      }
+    }
+  }
+`;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilter.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilter.tsx
@@ -114,7 +114,7 @@ const ETCFilter = ({}: ETCFilterProps) => {
       <ETCFilterAccordionStyle
         ref={accordionRef}
         className={cn(isAccordionOpen ? "open" : "close")}
-        _height={accordionHeight}
+        $height={accordionHeight}
       >
         <div className="container">
           <Controller

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilter.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilter.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useMemo, useRef, useState } from "react";
+import { ChevronUp, Filter as FilterIcon, Plus } from "react-feather";
+import { Controller, useFormContext } from "react-hook-form";
+
+import cn from "classnames";
+
+import FilterSelect from "@/components/molecules/FilterSelect/FilterSelect";
+
+import {
+  ETCFilterHeaderStyle,
+  ETCFilterAccordionStyle,
+  ETCFilterStyle,
+} from "./ETCFilterStyle";
+import ETCFilterTag from "../ETCFilterTag/ETCFilterTag";
+import {
+  useAllAssetsQuery,
+  useAllCategoriesQuery,
+  useAllTagsQuery,
+} from "../query";
+import { FilterInputs } from "../types";
+
+interface ETCFilterProps {
+  onChange?: (value: string) => void;
+}
+
+const ETCFilter = ({}: ETCFilterProps) => {
+  const { control, watch } = useFormContext<FilterInputs>();
+  const [isAccordionOpen, setIsAccordionOpen] = useState<boolean>(false);
+  const accordionRef = useRef<HTMLDivElement | null>(null);
+
+  const { data: assetsData } = useAllAssetsQuery();
+  const assetOptions = useMemo(
+    () => assetsData?.map(({ id, name }) => ({ label: name, value: id })) ?? [],
+    [assetsData],
+  );
+  const { data: categoriesData } = useAllCategoriesQuery();
+  const categoryOptions = useMemo(
+    () =>
+      categoriesData?.map(({ id, name }) => ({ label: name, value: id })) ?? [],
+    [categoriesData],
+  );
+  const { data: tagsData } = useAllTagsQuery();
+  const tagOptions = useMemo(
+    () => tagsData?.map(({ id, name }) => ({ label: name, value: id })) ?? [],
+    [tagsData],
+  );
+
+  const accordionHeight = useMemo(() => {
+    const { current } = accordionRef;
+    if (!current) return 0;
+    return isAccordionOpen ? current.scrollHeight : 0;
+  }, [isAccordionOpen]);
+
+  const toggleSelectsOpen = useCallback(
+    () => setIsAccordionOpen(!isAccordionOpen),
+    [isAccordionOpen],
+  );
+
+  const watchSelected = watch(["assetIds", "categoryIds", "tagIds"]);
+
+  const selectedETCTags = useMemo(() => {
+    const [assetIds, categoryIds, tagIds] = watchSelected;
+
+    const assetTags = assetIds
+      ?.map(id => assetsData?.find(data => data.id === id))
+      .map(({ id, name }) => ({
+        label: `${name}`,
+        value: id,
+        keyName: "assetIds" as const,
+      }));
+
+    const categoryTags = categoryIds
+      ?.map(id => categoriesData?.find(data => data.id === id))
+      .map(({ id, name }) => ({
+        label: `${name}`,
+        value: id,
+        keyName: "categoryIds" as const,
+      }));
+
+    const tagTags = tagIds
+      ?.map(id => tagsData?.find(data => data.id === id))
+      .map(({ id, name }) => ({
+        label: `${name}`,
+        value: id,
+        keyName: "tagIds" as const,
+      }));
+
+    return [...(assetTags ?? []), ...(categoryTags ?? []), ...(tagTags ?? [])];
+  }, [watchSelected]);
+
+  return (
+    <ETCFilterStyle className="filter-item">
+      <ETCFilterHeaderStyle>
+        <div className="title">
+          <div className="title-text">
+            <FilterIcon />
+            <p>필터</p>
+          </div>
+          <button className="title-toggle" onClick={toggleSelectsOpen}>
+            <Plus className={cn(!isAccordionOpen && "show")} />
+            <ChevronUp className={cn(isAccordionOpen && "show")} />
+          </button>
+        </div>
+
+        {selectedETCTags?.length > 0 && (
+          <div className="selected-filter">
+            {selectedETCTags.map(props => (
+              <ETCFilterTag key={`filter-${props.label}`} {...props} />
+            ))}
+          </div>
+        )}
+      </ETCFilterHeaderStyle>
+
+      <ETCFilterAccordionStyle
+        ref={accordionRef}
+        className={cn(isAccordionOpen ? "open" : "close")}
+        _height={accordionHeight}
+      >
+        <div className="container">
+          <Controller
+            control={control}
+            name="assetIds"
+            render={({ field }) => (
+              <FilterSelect
+                placeholder="자산"
+                options={assetOptions}
+                {...field}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name="categoryIds"
+            render={({ field }) => (
+              <FilterSelect
+                placeholder="카테고리"
+                options={categoryOptions}
+                {...field}
+              />
+            )}
+          />
+          <Controller
+            control={control}
+            name="tagIds"
+            render={({ field }) => (
+              <FilterSelect
+                placeholder="해시태그"
+                options={tagOptions}
+                {...field}
+              />
+            )}
+          />
+        </div>
+      </ETCFilterAccordionStyle>
+    </ETCFilterStyle>
+  );
+};
+
+export default ETCFilter;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilter.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilter.tsx
@@ -41,7 +41,7 @@ const ETCFilter = ({}: ETCFilterProps) => {
   );
   const { data: tagsData } = useAllTagsQuery();
   const tagOptions = useMemo(
-    () => tagsData?.map(({ id, name }) => ({ label: name, value: id })) ?? [],
+    () => tagsData?.map(({ name }) => ({ label: name, value: name })) ?? [],
     [tagsData],
   );
 
@@ -56,10 +56,10 @@ const ETCFilter = ({}: ETCFilterProps) => {
     [isAccordionOpen],
   );
 
-  const watchSelected = watch(["assetIds", "categoryIds", "tagIds"]);
+  const watchSelected = watch(["assetIds", "categoryIds", "tagNames"]);
 
   const selectedETCTags = useMemo(() => {
-    const [assetIds, categoryIds, tagIds] = watchSelected;
+    const [assetIds, categoryIds, tagNames] = watchSelected;
 
     const assetTags = assetIds
       ?.map(id => assetsData?.find(data => data.id === id))
@@ -77,12 +77,12 @@ const ETCFilter = ({}: ETCFilterProps) => {
         keyName: "categoryIds" as const,
       }));
 
-    const tagTags = tagIds
-      ?.map(id => tagsData?.find(data => data.id === id))
-      .map(({ id, name }) => ({
-        label: `${name}`,
-        value: id,
-        keyName: "tagIds" as const,
+    const tagTags = tagNames
+      ?.map(name => tagsData?.find(data => data.name === name))
+      .map(({ name }) => ({
+        label: `#${name}`,
+        value: name,
+        keyName: "tagNames" as const,
       }));
 
     return [...(assetTags ?? []), ...(categoryTags ?? []), ...(tagTags ?? [])];
@@ -141,7 +141,7 @@ const ETCFilter = ({}: ETCFilterProps) => {
           />
           <Controller
             control={control}
-            name="tagIds"
+            name="tagNames"
             render={({ field }) => (
               <FilterSelect
                 placeholder="해시태그"

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilterStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilterStyle.tsx
@@ -1,0 +1,106 @@
+import styled, { keyframes } from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+export const ETCFilterStyle = styled.div`
+  padding: 16px;
+
+  ${({ theme }) => theme.mq.desktop} {
+    padding: 20px;
+  }
+`;
+
+export const ETCFilterHeaderStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  .title {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    &-text {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      ${({ theme }) => expandTypography(theme.typography.body.medium.bold)}
+
+      > svg {
+        width: 16px;
+        height: 16px;
+        color: ${({ theme }) => theme.color.bluishGray[500].value};
+      }
+    }
+
+    &-toggle {
+      width: 20px;
+      height: 20px;
+      color: ${({ theme }) => theme.color.bluishGray[600].value};
+      > svg {
+        width: 100%;
+        height: 100%;
+        display: none;
+        &.show {
+          display: block;
+        }
+      }
+    }
+  }
+
+  .selected-filter {
+    display: flex;
+    flex-flow: row wrap;
+    gap: 6px;
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    .title {
+      &-text {
+        ${({ theme }) => expandTypography(theme.typography.body.large.bold)}
+
+        > svg {
+          width: 20px;
+          height: 20px;
+        }
+      }
+
+      &-toggle {
+        width: 24px;
+        height: 24px;
+      }
+    }
+  }
+`;
+
+const accordionOpen = keyframes`
+  0% {
+    overflow: hidden;
+  }
+  99% {
+    overflow: hidden;
+  }
+  100% {
+    overflow: visible;
+  }
+`;
+
+export const ETCFilterAccordionStyle = styled.div<{ _height: number }>`
+  max-height: ${({ _height }) => _height}px;
+  transition: max-height 0.3s ease;
+
+  .container {
+    padding-top: 24px;
+    display: flex;
+    flex-direction: row;
+    gap: 8px;
+  }
+
+  &.open {
+    animation: ${accordionOpen} 0.3s ease forwards;
+  }
+
+  &.close {
+    overflow: hidden;
+  }
+`;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilterStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilter/ETCFilterStyle.tsx
@@ -85,8 +85,8 @@ const accordionOpen = keyframes`
   }
 `;
 
-export const ETCFilterAccordionStyle = styled.div<{ _height: number }>`
-  max-height: ${({ _height }) => _height}px;
+export const ETCFilterAccordionStyle = styled.div<{ $height: number }>`
+  max-height: ${({ $height }) => $height}px;
   transition: max-height 0.3s ease;
 
   .container {

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilterTag/ETCFilterTag.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilterTag/ETCFilterTag.tsx
@@ -1,0 +1,33 @@
+import { X } from "react-feather";
+import { useFormContext } from "react-hook-form";
+
+import { ETCFilterTagStyle } from "./ETCFilterTagStyle";
+import { FilterInputs } from "../types";
+
+interface ETCFilterTagProps {
+  label: string;
+  value: number;
+  keyName: keyof Pick<FilterInputs, "assetIds" | "categoryIds" | "tagIds">;
+}
+
+const ETCFilterTag = ({ label, value, keyName }: ETCFilterTagProps) => {
+  const { getValues, setValue } = useFormContext<FilterInputs>();
+
+  const deleteTag = () => {
+    const values = getValues(keyName);
+    const filteredValues = values.filter(_value => _value !== value);
+    console.log(values);
+    setValue(keyName, filteredValues);
+  };
+
+  return (
+    <ETCFilterTagStyle>
+      <p>{label}</p>
+      <button>
+        <X onClick={deleteTag} />
+      </button>
+    </ETCFilterTagStyle>
+  );
+};
+
+export default ETCFilterTag;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilterTag/ETCFilterTag.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilterTag/ETCFilterTag.tsx
@@ -6,18 +6,21 @@ import { FilterInputs } from "../types";
 
 interface ETCFilterTagProps {
   label: string;
-  value: number;
-  keyName: keyof Pick<FilterInputs, "assetIds" | "categoryIds" | "tagIds">;
+  value: number | string;
+  keyName: keyof Pick<FilterInputs, "assetIds" | "categoryIds" | "tagNames">;
 }
 
 const ETCFilterTag = ({ label, value, keyName }: ETCFilterTagProps) => {
   const { getValues, setValue } = useFormContext<FilterInputs>();
 
   const deleteTag = () => {
-    const values = getValues(keyName);
-    const filteredValues = values.filter(_value => _value !== value);
-    console.log(values);
-    setValue(keyName, filteredValues);
+    if (keyName === "tagNames") {
+      const filteredValues = getValues(keyName).filter(v => v !== value);
+      setValue(keyName, filteredValues);
+    } else {
+      const filteredValues = getValues(keyName).filter(v => v !== value);
+      setValue(keyName, filteredValues);
+    }
   };
 
   return (

--- a/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilterTag/ETCFilterTagStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/ETCFilterTag/ETCFilterTagStyle.tsx
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+export const ETCFilterTagStyle = styled.div`
+  padding: 4px 10px;
+  color: ${({ theme }) => theme.color.white.value};
+  background-color: ${({ theme }) => theme.color.bluishGray[700].value};
+  ${({ theme }) => expandTypography(theme.typography.body.small.medium)}
+  border-radius: 50px;
+
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  button > svg {
+    width: 12px;
+    height: 12px;
+    color: ${({ theme }) => theme.color.bluishGray[400].value};
+  }
+`;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCell.stories.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCell.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import MyTransactionDetailCell from "./MyTransactionDetailCell";
+
+export default {
+  title: "MyTransactionsPage/MyTransactionDetailCell",
+  component: MyTransactionDetailCell,
+} as Meta<typeof MyTransactionDetailCell>;
+
+type Story = StoryObj<typeof MyTransactionDetailCell>;
+
+export const Detault: Story = {
+  args: {
+    id: 1,
+    amount: 50000,
+    type: "INCOME",
+    content: "제목 텍스트 텍스트",
+    reason: "설명 텍스트 텍스트 설명 텍스트 텍스트 설명 텍스트 텍스트",
+  },
+};

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCell.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCell.tsx
@@ -1,0 +1,44 @@
+import cn from "classnames";
+
+import { TypeTag } from "@/components/atoms";
+import { TxType } from "@/types";
+import { formatNumber } from "@/utils/format";
+
+import { MyTransactionDetailCellStyle } from "./MyTransactionDetailCellStyle";
+
+export interface MyTransactionDetailCellProps {
+  id: number;
+  type: TxType;
+  amount: number;
+  content: string;
+  reason: string;
+}
+
+const MyTransactionDetailCell = ({
+  id,
+  type,
+  amount,
+  content,
+  reason,
+}: MyTransactionDetailCellProps) => {
+  return (
+    <a href={`/detail/${id}`}>
+      <MyTransactionDetailCellStyle>
+        <div className="header">
+          <TypeTag txType={type} size="md" />
+          <div className={cn("amount", type)}>
+            <span>₩</span>
+            <span>{formatNumber(amount)}</span>
+          </div>
+        </div>
+
+        <div className="body">
+          <p className="content">{content}</p>
+          <p className="reason">{reason}</p>
+        </div>
+      </MyTransactionDetailCellStyle>
+    </a>
+  );
+};
+
+export default MyTransactionDetailCell;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellEmpty.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellEmpty.tsx
@@ -1,0 +1,14 @@
+import { Archive } from "react-feather";
+
+import { MyTransactionDetailCellEmptyStyle } from "./MyTransactionDetailCellStyle";
+
+const MyTransactionDetailCellEmpty = () => {
+  return (
+    <MyTransactionDetailCellEmptyStyle>
+      <Archive />
+      <p>조건에 맞는 데이터가 없습니다.</p>
+    </MyTransactionDetailCellEmptyStyle>
+  );
+};
+
+export default MyTransactionDetailCellEmpty;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellSkeleton.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellSkeleton.tsx
@@ -1,0 +1,25 @@
+import { ForwardedRef, forwardRef } from "react";
+
+import { MyTransactionDetailCellSkeletonStyle } from "./MyTransactionDetailCellStyle";
+
+const MyTransactionDetailCellSkeleton = forwardRef(
+  (_, ref: ForwardedRef<HTMLDivElement>) => {
+    return (
+      <MyTransactionDetailCellSkeletonStyle ref={ref}>
+        <div className="header animated-skeleton">
+          <div className="tag" />
+          <div className="amount" />
+        </div>
+        <div className="body animated-skeleton">
+          <div className="content" />
+          <div className="reason">
+            <div className="reason-line line-1" />
+            <div className="reason-line line-2" />
+          </div>
+        </div>
+      </MyTransactionDetailCellSkeletonStyle>
+    );
+  },
+);
+
+export default MyTransactionDetailCellSkeleton;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellStyle.tsx
@@ -156,3 +156,14 @@ export const MyTransactionDetailCellSkeletonStyle = styled.div`
     }
   }
 `;
+
+export const MyTransactionDetailCellEmptyStyle = styled.div`
+  padding: 24px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+
+  color: ${({ theme }) => theme.color.bluishGray[500].value};
+  ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+`;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionDetailCell/MyTransactionDetailCellStyle.tsx
@@ -1,0 +1,158 @@
+import styled, { css } from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+import { Tx } from "@/types";
+import { convertTxTypeToColor } from "@/utils/txType";
+
+export const MyTransactionDetailCellStyle = styled.div`
+  width: 100%;
+  padding: 24px;
+  background-color: ${({ theme }) => theme.color.white.value};
+  border-radius: 12px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  .header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+
+    .amount {
+      display: flex;
+      gap: 6px;
+
+      ${({ theme }) => expandTypography(theme.typography.title.small.bold)}
+      ${({ theme }) =>
+        Object.values(Tx).map(
+          type => css`
+            &.${type} {
+              color: ${theme.color[convertTxTypeToColor(type)][500].value};
+            }
+          `,
+        )}
+    }
+  }
+
+  .body {
+    color: ${({ theme }) => theme.color.bluishGray[900].value};
+
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    .content {
+      ${({ theme }) => expandTypography(theme.typography.body.large.bold)}
+    }
+
+    .reason {
+      ${({ theme }) => expandTypography(theme.typography.body.small.regular)}
+      opacity: 0.6;
+    }
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    border-radius: 16px;
+    gap: 32px;
+
+    .header {
+      .amount {
+        gap: 6px;
+        ${({ theme }) => expandTypography(theme.typography.title.medium.bold)}
+      }
+    }
+
+    .body {
+      .content {
+        ${({ theme }) => expandTypography(theme.typography.title.small2x.bold)}
+      }
+      .reason {
+        ${({ theme }) => expandTypography(theme.typography.body.medium.regular)}
+      }
+    }
+  }
+`;
+
+export const MyTransactionDetailCellSkeletonStyle = styled.div`
+  width: 100%;
+  height: 186px;
+  padding: 24px;
+  background-color: ${({ theme }) => theme.color.white.value};
+  border-radius: 12px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+
+  .header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+
+    .tag {
+      width: 36px;
+      height: 18px;
+      border-radius: 8px;
+      background-color: ${({ theme }) => theme.color.bluishGray[200].value};
+    }
+    .amount {
+      width: 95px;
+      height: 26px;
+      border-radius: 8px;
+      background-color: ${({ theme }) => theme.color.bluishGray[200].value};
+    }
+  }
+
+  .body {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+    .content {
+      width: 149px;
+      height: 22px;
+      border-radius: 8px;
+      background-color: ${({ theme }) => theme.color.bluishGray[200].value};
+    }
+
+    .reason {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+
+      &-line {
+        height: 14px;
+        border-radius: 6px;
+        background-color: ${({ theme }) => theme.color.bluishGray[200].value};
+        &.line-1 {
+          width: 100%;
+        }
+        &.line-2 {
+          width: 201px;
+        }
+      }
+    }
+  }
+
+  .animated-skeleton {
+    animation: pulse 1.5s infinite;
+    &.body {
+      animation-delay: 0.2s;
+    }
+  }
+
+  @keyframes pulse {
+    0% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+`;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionsPageStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionsPageStyle.tsx
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 
 export const FilteBoxStyle = styled.form`
+  margin-bottom: 40px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -10,4 +11,10 @@ export const FilteBoxStyle = styled.form`
     background-color: ${({ theme }) => theme.color.bluishGray[100].value};
     color: ${({ theme }) => theme.color.bluishGray[700].value};
   }
+`;
+
+export const MyTransactionCellsStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 `;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionsPageStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/MyTransactionsPageStyle.tsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+export const FilteBoxStyle = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .filter-item {
+    border-radius: 12px;
+    background-color: ${({ theme }) => theme.color.bluishGray[100].value};
+    color: ${({ theme }) => theme.color.bluishGray[700].value};
+  }
+`;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/TxTypeFilter/TxTypeFilter.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/TxTypeFilter/TxTypeFilter.tsx
@@ -1,0 +1,49 @@
+import { ForwardedRef, forwardRef, useCallback, useState } from "react";
+import { ControllerRenderProps } from "react-hook-form";
+
+import cn from "classnames";
+
+import { Tx, TxType } from "@/types";
+import { convertTxTypeToWord } from "@/utils/txType";
+
+import { TxTypeFilterStyle, TxTypeFilterTabStyle } from "./TxTypeFilterStyle";
+
+interface TxTypeFilterProps extends Omit<ControllerRenderProps, "ref"> {}
+
+const TxTypeFilter = forwardRef(
+  (
+    { value, onChange }: TxTypeFilterProps,
+    ref: ForwardedRef<HTMLDivElement>,
+  ) => {
+    const [selected, setSelected] = useState<TxType | undefined>(value);
+
+    const selectTxHandler = useCallback(
+      (tx: TxType) => () => {
+        if (selected === tx) {
+          setSelected(undefined);
+          onChange(undefined);
+        } else {
+          setSelected(tx);
+          onChange(tx);
+        }
+      },
+      [selected, onChange],
+    );
+
+    return (
+      <TxTypeFilterStyle className="filter-item" ref={ref}>
+        {Object.values(Tx).map(tx => (
+          <TxTypeFilterTabStyle
+            key={`txtype-filter-tab-${tx}`}
+            className={cn(tx, { selected: selected === tx })}
+            onClick={selectTxHandler(tx)}
+          >
+            {convertTxTypeToWord(tx)}
+          </TxTypeFilterTabStyle>
+        ))}
+      </TxTypeFilterStyle>
+    );
+  },
+);
+
+export default TxTypeFilter;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/TxTypeFilter/TxTypeFilterStyle.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/TxTypeFilter/TxTypeFilterStyle.tsx
@@ -1,0 +1,44 @@
+import styled, { css } from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+import { Tx } from "@/types";
+import { convertTxTypeToColor } from "@/utils/txType";
+
+export const TxTypeFilterStyle = styled.div`
+  padding: 4px;
+  display: flex;
+  justify-content: stretch;
+
+  ${({ theme }) => theme.mq.desktop} {
+    padding: 6px;
+  }
+`;
+
+export const TxTypeFilterTabStyle = styled.button`
+  height: 40px;
+  color: ${({ theme }) => theme.color.bluishGray[500].value};
+  ${({ theme }) => expandTypography(theme.typography.body.medium.bold)}
+  border-radius: 8px;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
+
+  &.selected {
+    background-color: ${({ theme }) => theme.color.white.value};
+    ${({ theme }) =>
+      Object.values(Tx).map(
+        type => css`
+          &.${type} {
+            color: ${theme.color[convertTxTypeToColor(type)][600].value};
+          }
+        `,
+      )}
+  }
+
+  ${({ theme }) => theme.mq.desktop} {
+    height: 48px;
+    ${({ theme }) => expandTypography(theme.typography.body.large.bold)}
+  }
+`;

--- a/frontend/tiggle/src/pages/MyTransactionsPage/controller.ts
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/controller.ts
@@ -1,0 +1,105 @@
+import {
+  FormEventHandler,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useForm, useWatch } from "react-hook-form";
+
+import dayjs, { Dayjs } from "dayjs";
+
+import { MemberDto, TransactionRespDto } from "@/generated";
+
+import { useTransactionsQueryByMember } from "./query";
+import { FilterInputs } from "./types";
+
+const pageSize = 3;
+
+export const useMyTransactionsPage = (profile: MemberDto) => {
+  const method = useForm<FilterInputs>({ defaultValues: { date: dayjs() } });
+  const handleSubmit: FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+  };
+
+  const filterWatch = useWatch({ control: method.control });
+
+  const filter = useCallback(
+    (data: TransactionRespDto) => {
+      const { date, txType, assetIds, categoryIds, tagNames } = filterWatch;
+
+      const isTxMatched = txType ? data.type === txType : true;
+      const isDateMatched = date
+        ? dayjs(data.createdAt).isSame(date as Dayjs, "month")
+        : true;
+      const isAssetMatched =
+        assetIds?.length > 0 ? assetIds.includes(data.asset.id) : true;
+      const isCategoryMatched =
+        categoryIds?.length > 0 ? categoryIds.includes(data.category.id) : true;
+      const isTagMatched =
+        tagNames?.length > 0
+          ? data.txTagNames?.split(", ").some(tag => tagNames.includes(tag))
+          : true;
+
+      return (
+        isTxMatched &&
+        isDateMatched &&
+        isAssetMatched &&
+        isCategoryMatched &&
+        isTagMatched
+      );
+    },
+    [filterWatch],
+  );
+
+  // TODO filtering 적용하기
+  // AllTx -> FilteredTx -> SlicedTx
+  const { data: transactionsData } = useTransactionsQueryByMember(profile.id);
+  const [filteredTx, setFilteredTx] = useState<TransactionRespDto[]>([]);
+  useEffect(() => {
+    if (transactionsData) {
+      setFilteredTx(transactionsData.content.filter(filter));
+    }
+  }, [filter, transactionsData]);
+
+  const [index, setIndex] = useState(0);
+  const sliceSize = useMemo(() => (index + 1) * pageSize, [index]);
+  const isLoadable = useMemo(
+    () => sliceSize < filteredTx.length,
+    [filteredTx, sliceSize],
+  );
+
+  const [entry, setEntry] = useState<IntersectionObserverEntry>();
+  const loaderRef = useRef<HTMLDivElement | null>(null);
+  const updateEntry = ([entry]: IntersectionObserverEntry[]) => {
+    setEntry(entry);
+  };
+
+  useEffect(() => {
+    if (entry?.isIntersecting && isLoadable) {
+      console.log("load more!");
+      setIndex(index + 1);
+    }
+  }, [entry, isLoadable]);
+
+  useEffect(() => {
+    const node = loaderRef?.current;
+    if (!node) return;
+
+    const observerParams = { threshold: 0.5, rootMargin: "0%" };
+    const observer = new IntersectionObserver(updateEntry, observerParams);
+    observer.observe(node);
+
+    () => observer.disconnect();
+  }, [loaderRef?.current, isLoadable]);
+
+  return {
+    form: { method, handleSubmit },
+    data: {
+      transactions: filteredTx.slice(0, sliceSize),
+      isLoadable,
+      loaderRef,
+    },
+  };
+};

--- a/frontend/tiggle/src/pages/MyTransactionsPage/index.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/index.tsx
@@ -42,7 +42,7 @@ const MyTransactionsPage = ({ profile }: MyTransactionPageProps) => {
       </FormProvider>
 
       <MyTransactionCellsStyle>
-        {data.transactions.map((data: MyTransactionDetailCellProps) => (
+        {data.transactions?.map((data: MyTransactionDetailCellProps) => (
           <MyTransactionDetailCell
             key={`transaction-cell-${data.id}`}
             {...data}

--- a/frontend/tiggle/src/pages/MyTransactionsPage/index.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/index.tsx
@@ -1,58 +1,57 @@
-import { FormEventHandler, useEffect } from "react";
-import { Controller, FormProvider, useForm } from "react-hook-form";
-
-import dayjs from "dayjs";
+import { Controller, FormProvider } from "react-hook-form";
 
 import withAuth, { AuthProps } from "@/utils/withAuth";
 
 import DateFilter from "./DateFilter/DateFilter";
 import ETCFilter from "./ETCFilter/ETCFilter";
-import { FilteBoxStyle } from "./MyTransactionsPageStyle";
+import MyTransactionDetailCell, {
+  MyTransactionDetailCellProps,
+} from "./MyTransactionDetailCell/MyTransactionDetailCell";
+import MyTransactionDetailCellSkeleton from "./MyTransactionDetailCell/MyTransactionDetailCellSkeleton";
+import {
+  FilteBoxStyle,
+  MyTransactionCellsStyle,
+} from "./MyTransactionsPageStyle";
 import TxTypeFilter from "./TxTypeFilter/TxTypeFilter";
-import { useTransactionsQueryByMember } from "./query";
-import { FilterInputs } from "./types";
+import { useMyTransactionsPage } from "./controller";
 import { MypageDetailPageStyle } from "../MyProfilePage/MyDetailPageCommonStyle";
 
 interface MyTransactionPageProps extends AuthProps {}
 
 const MyTransactionsPage = ({ profile }: MyTransactionPageProps) => {
-  const method = useForm<FilterInputs>({
-    defaultValues: { date: dayjs() },
-  });
-
-  const { data: transactionsData } = useTransactionsQueryByMember(profile.id);
-  console.log(transactionsData);
-
-  useEffect(() => {
-    const subscription = method.watch((value, { name, type }) =>
-      console.log(value, name, type),
-    );
-    return () => subscription.unsubscribe();
-  }, [method.watch]);
-
-  const handleSubmit: FormEventHandler<HTMLFormElement> = e => {
-    e.preventDefault();
-  };
+  const { form, data } = useMyTransactionsPage(profile);
 
   return (
     <MypageDetailPageStyle>
       <p className="page-title">내 기록 모아보기</p>
 
-      <FormProvider {...method}>
-        <FilteBoxStyle onSubmit={handleSubmit}>
+      <FormProvider {...form.method}>
+        <FilteBoxStyle onSubmit={form.handleSubmit}>
           <Controller
-            control={method.control}
+            control={form.method.control}
             name="date"
             render={({ field }) => <DateFilter {...field} />}
           />
           <Controller
-            control={method.control}
+            control={form.method.control}
             name="txType"
             render={({ field }) => <TxTypeFilter {...field} />}
           />
           <ETCFilter />
         </FilteBoxStyle>
       </FormProvider>
+
+      <MyTransactionCellsStyle>
+        {data.transactions.map((data: MyTransactionDetailCellProps) => (
+          <MyTransactionDetailCell
+            key={`transaction-cell-${data.id}`}
+            {...data}
+          />
+        ))}
+        {data.isLoadable && (
+          <MyTransactionDetailCellSkeleton ref={data.loaderRef} />
+        )}
+      </MyTransactionCellsStyle>
     </MypageDetailPageStyle>
   );
 };

--- a/frontend/tiggle/src/pages/MyTransactionsPage/index.tsx
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/index.tsx
@@ -1,0 +1,60 @@
+import { FormEventHandler, useEffect } from "react";
+import { Controller, FormProvider, useForm } from "react-hook-form";
+
+import dayjs from "dayjs";
+
+import withAuth, { AuthProps } from "@/utils/withAuth";
+
+import DateFilter from "./DateFilter/DateFilter";
+import ETCFilter from "./ETCFilter/ETCFilter";
+import { FilteBoxStyle } from "./MyTransactionsPageStyle";
+import TxTypeFilter from "./TxTypeFilter/TxTypeFilter";
+import { useTransactionsQueryByMember } from "./query";
+import { FilterInputs } from "./types";
+import { MypageDetailPageStyle } from "../MyProfilePage/MyDetailPageCommonStyle";
+
+interface MyTransactionPageProps extends AuthProps {}
+
+const MyTransactionsPage = ({ profile }: MyTransactionPageProps) => {
+  const method = useForm<FilterInputs>({
+    defaultValues: { date: dayjs() },
+  });
+
+  const { data: transactionsData } = useTransactionsQueryByMember(profile.id);
+  console.log(transactionsData);
+
+  useEffect(() => {
+    const subscription = method.watch((value, { name, type }) =>
+      console.log(value, name, type),
+    );
+    return () => subscription.unsubscribe();
+  }, [method.watch]);
+
+  const handleSubmit: FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+  };
+
+  return (
+    <MypageDetailPageStyle>
+      <p className="page-title">내 기록 모아보기</p>
+
+      <FormProvider {...method}>
+        <FilteBoxStyle onSubmit={handleSubmit}>
+          <Controller
+            control={method.control}
+            name="date"
+            render={({ field }) => <DateFilter {...field} />}
+          />
+          <Controller
+            control={method.control}
+            name="txType"
+            render={({ field }) => <TxTypeFilter {...field} />}
+          />
+          <ETCFilter />
+        </FilteBoxStyle>
+      </FormProvider>
+    </MypageDetailPageStyle>
+  );
+};
+
+export default withAuth(MyTransactionsPage);

--- a/frontend/tiggle/src/pages/MyTransactionsPage/query.ts
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/query.ts
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  AssetApiControllerService,
+  CategoryApiControllerService,
+  TagApiControllerService,
+  TransactionApiControllerService,
+} from "@/generated";
+import {
+  assetKeys,
+  categoryKeys,
+  tagKeys,
+  transactionKeys,
+} from "@/query/queryKeys";
+
+export const useAllAssetsQuery = () =>
+  useQuery({
+    queryKey: assetKeys.lists(),
+    queryFn: async () => AssetApiControllerService.getAllAsset(),
+  });
+
+export const useAllCategoriesQuery = () =>
+  useQuery({
+    queryKey: categoryKeys.lists(),
+    queryFn: async () => CategoryApiControllerService.getAllCategory(),
+  });
+
+export const useAllTagsQuery = () =>
+  useQuery({
+    queryKey: tagKeys.lists(),
+    queryFn: async () => TagApiControllerService.getAllDefaultTag(),
+  });
+
+export const useTransactionsQueryByMember = (memberId: number) =>
+  useQuery({
+    queryKey: transactionKeys.list({ memberId }),
+    queryFn: async () =>
+      TransactionApiControllerService.getMemberCountOffsetTransaction(
+        memberId,
+        0,
+      ),
+  });

--- a/frontend/tiggle/src/pages/MyTransactionsPage/query.ts
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/query.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import dayjs from "dayjs";
 
 import {
   AssetApiControllerService,
@@ -12,6 +13,7 @@ import {
   tagKeys,
   transactionKeys,
 } from "@/query/queryKeys";
+import { TxType } from "@/types";
 
 export const useAllAssetsQuery = () =>
   useQuery({
@@ -41,3 +43,57 @@ export const useTransactionsQueryByMember = (memberId: number) =>
         100, // TODO: Transaction API filtering 기능 개발 후, infinite scroll 구현
       ),
   });
+
+type TxFilter = {
+  assetIds: number[];
+  categoryIds: number[];
+  tagNames: string[];
+  type: TxType;
+  date: string;
+};
+
+export const useTransactionQueryByFilter = (
+  memberId: number,
+  filter: Partial<TxFilter>,
+) => {
+  return useQuery({
+    queryKey: transactionKeys.list({ memberId, ...filter }),
+    queryFn: async () =>
+      TransactionApiControllerService.getMemberCountOffsetTransaction(
+        memberId,
+        0,
+        100,
+      )
+        .then(({ content }) => {
+          if (!filter.date) return content;
+          return content.filter(data =>
+            dayjs(filter.date).isSame(dayjs(data.date), "month"),
+          );
+        })
+        .then(content => {
+          if (!filter.assetIds || !filter.assetIds.length) return content;
+          return content.filter(data =>
+            filter.assetIds.includes(data.asset.id),
+          );
+        })
+        .then(content => {
+          if (!filter.categoryIds || !filter.categoryIds.length) return content;
+          return content.filter(data =>
+            filter.categoryIds.includes(data.category.id),
+          );
+        })
+        .then(content => {
+          if (!filter.tagNames || !filter.tagNames.length) return content;
+          return content.filter(
+            data =>
+              data.txTagNames
+                ?.split(", ")
+                .some(tagName => filter.tagNames.includes(tagName)),
+          );
+        })
+        .then(content => {
+          if (!filter.type) return content;
+          return content.filter(data => data.type === filter.type);
+        }),
+  });
+};

--- a/frontend/tiggle/src/pages/MyTransactionsPage/query.ts
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/query.ts
@@ -38,5 +38,6 @@ export const useTransactionsQueryByMember = (memberId: number) =>
       TransactionApiControllerService.getMemberCountOffsetTransaction(
         memberId,
         0,
+        100, // TODO: Transaction API filtering 기능 개발 후, infinite scroll 구현
       ),
   });

--- a/frontend/tiggle/src/pages/MyTransactionsPage/types.ts
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/types.ts
@@ -1,0 +1,11 @@
+import { Dayjs } from "dayjs";
+
+import { TxType } from "@/types";
+
+export interface FilterInputs {
+  assetIds: Array<number>;
+  categoryIds: Array<number>;
+  tagIds: Array<number>;
+  txType: TxType;
+  date: Dayjs;
+}

--- a/frontend/tiggle/src/pages/MyTransactionsPage/types.ts
+++ b/frontend/tiggle/src/pages/MyTransactionsPage/types.ts
@@ -5,7 +5,7 @@ import { TxType } from "@/types";
 export interface FilterInputs {
   assetIds: Array<number>;
   categoryIds: Array<number>;
-  tagIds: Array<number>;
+  tagNames: Array<string>;
   txType: TxType;
   date: Dayjs;
 }

--- a/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useMutation } from "@tanstack/react-query";
 
-import { ItemWrapperStyle } from "./AssetSettingPageStyle";
-import Item from "./Item/Item";
-import ItemAdd from "./ItemAdd/ItemAdd";
+import { Loading } from "@/components/atoms";
+import { AssetApiControllerService } from "@/generated";
+
+import SettingForm from "./SettingForm/SettingForm";
 import { useAssetsQuery } from "./query";
 import { MypageDetailPageStyle } from "../MyProfilePage/MyDetailPageCommonStyle";
 
@@ -18,46 +18,36 @@ export type AssetsInput = {
 };
 
 const AssetSettingPage = ({}: AssetSettingPageProps) => {
-  const { data: assetsData } = useAssetsQuery();
+  const { data: assetsData, isLoading } = useAssetsQuery();
 
-  const { control, setValue } = useForm<AssetsInput>({
-    defaultValues: { [fieldArrayName]: [] },
-  });
-  const { fields, append, update, remove } = useFieldArray({
-    control,
-    name: fieldArrayName,
-  });
+  const { mutate } = useMutation(async (name: string) =>
+    AssetApiControllerService.createAsset({ name }),
+  );
 
-  const appendField = () => {
-    append({ sid: -1, label: "" });
+  const create = (value: string) => {
+    mutate(value);
+    console.log(`ASSET PAGE - create api called`, value);
   };
-
-  useEffect(() => {
-    if (assetsData) {
-      setValue(
-        fieldArrayName,
-        assetsData.map(({ id, name }) => ({ sid: id, label: name })),
-      );
-    }
-  }, [assetsData]);
+  const update = (sid: number, newValue: string) => {
+    // TODO: API 연결
+    console.log(`ASSET PAGE - update api called`, sid, newValue);
+  };
+  const remove = (sid: number) => {
+    // TODO: API 연결
+    console.log(`ASSET PAGE - remove api called`, sid);
+  };
 
   return (
     <MypageDetailPageStyle>
       <p className="page-title">내 자산 관리</p>
 
-      <ItemWrapperStyle>
-        {fields.map((field, index) => (
-          <Item
-            key={`asset-item-${field.id}`}
-            index={index}
-            value={field}
-            updateField={update}
-            removeField={remove}
-            defaultStatus={field.label === "" ? "edit" : "display"}
-          />
-        ))}
-        <ItemAdd onClick={appendField} />
-      </ItemWrapperStyle>
+      {isLoading && <Loading />}
+      {!isLoading && assetsData && (
+        <SettingForm
+          data={assetsData.map(({ id, name }) => ({ sid: id, name }))}
+          requests={{ create, update, remove }}
+        />
+      )}
     </MypageDetailPageStyle>
   );
 };

--- a/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
@@ -1,50 +1,78 @@
+import { useCallback } from "react";
+
 import { useMutation } from "@tanstack/react-query";
 
 import { Loading } from "@/components/atoms";
 import { AssetApiControllerService } from "@/generated";
+import useMessage from "@/hooks/useMessage";
+import queryClient from "@/query/queryClient";
+import { assetKeys } from "@/query/queryKeys";
+import withAuth, { AuthProps } from "@/utils/withAuth";
 
 import SettingForm from "./SettingForm/SettingForm";
 import { useAssetsQuery } from "./query";
 import { MypageDetailPageStyle } from "../MyProfilePage/MyDetailPageCommonStyle";
 
-interface AssetSettingPageProps {}
-
-const fieldArrayName = "assetList";
-export type AssetsInput = {
-  [fieldArrayName]: {
-    sid: number;
-    label: string;
-  }[];
-};
+interface AssetSettingPageProps extends AuthProps {}
 
 const AssetSettingPage = ({}: AssetSettingPageProps) => {
-  const { data: assetsData, isLoading } = useAssetsQuery();
-
-  const { mutate } = useMutation(async (name: string) =>
+  const messageApi = useMessage();
+  const { data, isLoading: isDataLoading } = useAssetsQuery();
+  const { mutate: createMutate } = useMutation(async (name: string) =>
     AssetApiControllerService.createAsset({ name }),
   );
 
-  const create = (value: string) => {
-    mutate(value);
-    console.log(`ASSET PAGE - create api called`, value);
-  };
-  const update = (sid: number, newValue: string) => {
-    // TODO: API 연결
-    console.log(`ASSET PAGE - update api called`, sid, newValue);
-  };
-  const remove = (sid: number) => {
-    // TODO: API 연결
-    console.log(`ASSET PAGE - remove api called`, sid);
-  };
+  const create = useCallback(
+    (
+      value: string,
+      callback?: (data: { id: number; name: string }) => void,
+    ) => {
+      return createMutate(value, {
+        onSuccess: ({ id, name }) => {
+          callback?.({ id, name });
+          queryClient.invalidateQueries({ queryKey: assetKeys.lists() });
+          messageApi.open({ type: "success", content: "자산 생성 성공" });
+        },
+        onError: () => {
+          messageApi.open({ type: "error", content: "자산 생성 실패" });
+        },
+      });
+    },
+    [createMutate],
+  );
+
+  const update = useCallback(
+    (
+      sid: number,
+      newValue: string,
+      callback?: (data: { id: number; name: string }) => void,
+    ) => {
+      // TODO: API 연결
+      callback?.({ id: sid, name: newValue });
+      console.log(`ASSET PAGE - update api called`, sid, newValue);
+      messageApi.open({ type: "success", content: "자산 수정 성공" });
+    },
+    [],
+  );
+
+  const remove = useCallback(
+    (sid: number, callback?: (data: { id: number; name: string }) => void) => {
+      // TODO: API 연결
+      callback({ id: sid, name: "temp" });
+      console.log(`ASSET PAGE - remove api called`, sid);
+      messageApi.open({ type: "success", content: "자산 삭제 성공" });
+    },
+    [],
+  );
 
   return (
     <MypageDetailPageStyle>
       <p className="page-title">내 자산 관리</p>
 
-      {isLoading && <Loading />}
-      {!isLoading && assetsData && (
+      {isDataLoading && <Loading />}
+      {!isDataLoading && data && (
         <SettingForm
-          data={assetsData.map(({ id, name }) => ({ sid: id, name }))}
+          data={data.map(({ id, name }) => ({ sid: id, name }))}
           requests={{ create, update, remove }}
         />
       )}
@@ -52,4 +80,4 @@ const AssetSettingPage = ({}: AssetSettingPageProps) => {
   );
 };
 
-export default AssetSettingPage;
+export default withAuth(AssetSettingPage);

--- a/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
@@ -67,7 +67,7 @@ const AssetSettingPage = ({}: AssetSettingPageProps) => {
 
   return (
     <MypageDetailPageStyle>
-      <p className="page-title">내 자산 관리</p>
+      <p className="page-title">자산 관리</p>
 
       {isDataLoading && <Loading />}
       {!isDataLoading && data && (

--- a/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/AssetSettingPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+
+import { ItemWrapperStyle } from "./AssetSettingPageStyle";
+import Item from "./Item/Item";
+import ItemAdd from "./ItemAdd/ItemAdd";
+import { useAssetsQuery } from "./query";
+import { MypageDetailPageStyle } from "../MyProfilePage/MyDetailPageCommonStyle";
+
+interface AssetSettingPageProps {}
+
+const fieldArrayName = "assetList";
+export type AssetsInput = {
+  [fieldArrayName]: {
+    sid: number;
+    label: string;
+  }[];
+};
+
+const AssetSettingPage = ({}: AssetSettingPageProps) => {
+  const { data: assetsData } = useAssetsQuery();
+
+  const { control, setValue } = useForm<AssetsInput>({
+    defaultValues: { [fieldArrayName]: [] },
+  });
+  const { fields, append, update, remove } = useFieldArray({
+    control,
+    name: fieldArrayName,
+  });
+
+  const appendField = () => {
+    append({ sid: -1, label: "" });
+  };
+
+  useEffect(() => {
+    if (assetsData) {
+      setValue(
+        fieldArrayName,
+        assetsData.map(({ id, name }) => ({ sid: id, label: name })),
+      );
+    }
+  }, [assetsData]);
+
+  return (
+    <MypageDetailPageStyle>
+      <p className="page-title">내 자산 관리</p>
+
+      <ItemWrapperStyle>
+        {fields.map((field, index) => (
+          <Item
+            key={`asset-item-${field.id}`}
+            index={index}
+            value={field}
+            updateField={update}
+            removeField={remove}
+            defaultStatus={field.label === "" ? "edit" : "display"}
+          />
+        ))}
+        <ItemAdd onClick={appendField} />
+      </ItemWrapperStyle>
+    </MypageDetailPageStyle>
+  );
+};
+
+export default AssetSettingPage;

--- a/frontend/tiggle/src/pages/SettingPage/AssetSettingPageStyle.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/AssetSettingPageStyle.tsx
@@ -1,0 +1,60 @@
+import styled from "styled-components";
+
+import { expandTypography } from "@/styles/util";
+
+export const ItemStyle = styled.li`
+  padding: 12px 16px;
+  background-color: ${({ theme }) => theme.color.white.value};
+  border-radius: 12px;
+
+  display: flex;
+  gap: 16px;
+
+  .label {
+    color: ${({ theme }) => theme.color.bluishGray[700].value};
+    ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+    flex-grow: 1;
+  }
+
+  .controllers {
+    > button {
+      color: ${({ theme }) => theme.color.blue[500].value};
+      ${({ theme }) => expandTypography(theme.typography.body.medium.regular)}
+    }
+
+    display: flex;
+    gap: 16px;
+  }
+`;
+
+export const ItemEditInputStyle = styled.input`
+  border: none;
+  outline: none;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.color.bluishGray[400].value};
+  }
+`;
+
+export const ItemAddStyle = styled.button`
+  padding: 12px 16px;
+  background-color: ${({ theme }) => theme.color.white.value};
+  color: ${({ theme }) => theme.color.blue[500].value};
+  border-radius: 12px;
+  ${({ theme }) => expandTypography(theme.typography.body.medium.medium)}
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  > svg {
+    width: 14px;
+    height: 14px;
+  }
+`;
+
+export const ItemWrapperStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;

--- a/frontend/tiggle/src/pages/SettingPage/IncomeCategorySettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/IncomeCategorySettingPage.tsx
@@ -1,0 +1,86 @@
+import { useCallback } from "react";
+
+import { useMutation } from "@tanstack/react-query";
+
+import { Loading } from "@/components/atoms";
+import { CategoryApiControllerService } from "@/generated";
+import useMessage from "@/hooks/useMessage";
+import queryClient from "@/query/queryClient";
+import { categoryKeys } from "@/query/queryKeys";
+import { Tx } from "@/types";
+import withAuth, { AuthProps } from "@/utils/withAuth";
+
+import SettingForm from "./SettingForm/SettingForm";
+import { useCategoryQueryByTx } from "./query";
+import { MypageDetailPageStyle } from "../MyProfilePage/MyDetailPageCommonStyle";
+
+interface IncomeCategorySettingPageProps extends AuthProps {}
+
+const IncomeCategorySettingPage = ({}: IncomeCategorySettingPageProps) => {
+  const messageApi = useMessage();
+  const { data: categoriesData, isLoading } = useCategoryQueryByTx(Tx.INCOME);
+  const { mutate: createMutate } = useMutation(async (name: string) =>
+    CategoryApiControllerService.createCategory({ name }),
+  );
+
+  const create = useCallback(
+    (
+      value: string,
+      callback?: (data: { id: number; name: string }) => void,
+    ) => {
+      createMutate(value, {
+        onSuccess: ({ id, name }) => {
+          callback?.({ id, name });
+          queryClient.invalidateQueries({
+            queryKey: categoryKeys.list({ type: Tx.INCOME }),
+          });
+          messageApi.open({ type: "success", content: "카테고리 생성 성공" });
+        },
+        onError: () => {
+          messageApi.open({ type: "error", content: "카테고리 생성 실패" });
+        },
+      });
+    },
+    [createMutate],
+  );
+
+  const update = useCallback(
+    (
+      sid: number,
+      newValue: string,
+      callback?: (data: { id: number; name: string }) => void,
+    ) => {
+      // TODO: API 연결
+      callback({ id: sid, name: newValue });
+      console.log(`INCOME CATEGORY PAGE - update api called`, sid, newValue);
+      messageApi.open({ type: "success", content: "카테고리 수정 성공" });
+    },
+    [],
+  );
+
+  const remove = useCallback(
+    (sid: number, callback?: (data: { id: number; name: string }) => void) => {
+      // TODO: API 연결
+      callback({ id: sid, name: "temp" });
+      console.log(`INCOME CATEGORY PAGE - delete api called`, sid);
+      messageApi.open({ type: "success", content: "카테고리 삭제 성공" });
+    },
+    [],
+  );
+
+  return (
+    <MypageDetailPageStyle>
+      <p className="page-title">내 수입 카테고리 관리</p>
+
+      {isLoading && <Loading />}
+      {!isLoading && categoriesData && (
+        <SettingForm
+          data={categoriesData.map(({ id, name }) => ({ sid: id, name }))}
+          requests={{ create, update, remove }}
+        />
+      )}
+    </MypageDetailPageStyle>
+  );
+};
+
+export default withAuth(IncomeCategorySettingPage);

--- a/frontend/tiggle/src/pages/SettingPage/IncomeCategorySettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/IncomeCategorySettingPage.tsx
@@ -70,7 +70,7 @@ const IncomeCategorySettingPage = ({}: IncomeCategorySettingPageProps) => {
 
   return (
     <MypageDetailPageStyle>
-      <p className="page-title">내 수입 카테고리 관리</p>
+      <p className="page-title">수입 카테고리 관리</p>
 
       {isLoading && <Loading />}
       {!isLoading && categoriesData && (

--- a/frontend/tiggle/src/pages/SettingPage/Item/Item.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/Item.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 import ItemDisplay from "./ItemDisplay";
 import ItemEdit from "./ItemEdit";
-import { SettingItem } from "../SettingForm/useSettingForm";
+import { SettingItem } from "../SettingForm/types";
 
 type ItemStatus = "display" | "edit";
 
@@ -32,12 +32,21 @@ const Item = ({ value, save, deleteSelf, defaultStatus }: ItemProps) => {
     } else {
       setStatus("display");
     }
-  }, [status, value]);
+  }, [status, value, deleteSelf]);
+
+  const handleDelete = useCallback(() => {
+    // TODO: open alert 로직 추가
+    deleteSelf();
+  }, [deleteSelf]);
 
   return status === "edit" ? (
     <ItemEdit label={value.name} onCancel={handleCancel} onSave={handleSave} />
   ) : (
-    <ItemDisplay label={value.name} onEdit={handleEdit} onDelete={deleteSelf} />
+    <ItemDisplay
+      label={value.name}
+      onEdit={handleEdit}
+      onDelete={handleDelete}
+    />
   );
 };
 

--- a/frontend/tiggle/src/pages/SettingPage/Item/Item.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/Item.tsx
@@ -1,54 +1,43 @@
 import { useCallback, useState } from "react";
-import { UseFieldArrayRemove, UseFieldArrayUpdate } from "react-hook-form";
 
-import { AssetsInput } from "../AssetSettingPage";
-import ItemDisplay from "../ItemDisplay/ItemDisplay";
-import ItemEdit from "../ItemEdit/ItemEdit";
+import ItemDisplay from "./ItemDisplay";
+import ItemEdit from "./ItemEdit";
+import { SettingItem } from "../SettingForm/useSettingForm";
 
 type ItemStatus = "display" | "edit";
 
 interface ItemProps {
-  index: number;
-  value: {
-    sid: number;
-    label: string;
-  };
-  updateField: UseFieldArrayUpdate<AssetsInput>;
-  removeField: UseFieldArrayRemove;
+  value: SettingItem;
+  save: (newValue: string) => void;
+  deleteSelf: () => void;
   defaultStatus?: ItemStatus;
 }
 
-const Item = ({
-  index,
-  value,
-  updateField,
-  removeField,
-  defaultStatus,
-}: ItemProps) => {
+const Item = ({ value, save, deleteSelf, defaultStatus }: ItemProps) => {
   const [status, setStatus] = useState<ItemStatus>(defaultStatus || "display");
 
-  const edit = useCallback(() => setStatus("edit"), [status]);
-  const cancel = useCallback(() => setStatus("display"), [status]);
-  const save = (newValue: string) => {
+  const handleEdit = useCallback(() => setStatus("edit"), [status]);
+
+  const handleSave = useCallback(
+    (newValue: string) => {
+      save(newValue);
+      setStatus("display");
+    },
+    [status, save],
+  );
+
+  const handleCancel = useCallback(() => {
     if (value.sid === -1) {
-      // TODO: Asset Create API 연결
-      console.log("create asset");
+      deleteSelf();
     } else {
-      // TODO: Asset Update API 연결
-      console.log("update asset");
+      setStatus("display");
     }
-    updateField(index, { ...value, label: newValue });
-  };
-  const remove = () => {
-    // TODO: alert
-    removeField(index);
-    // TODO: Asset Delete API 연결
-  };
+  }, [status, value]);
 
   return status === "edit" ? (
-    <ItemEdit label={value.label} onCancel={cancel} onSave={save} />
+    <ItemEdit label={value.name} onCancel={handleCancel} onSave={handleSave} />
   ) : (
-    <ItemDisplay label={value.label} onEdit={edit} onRemove={remove} />
+    <ItemDisplay label={value.name} onEdit={handleEdit} onDelete={deleteSelf} />
   );
 };
 

--- a/frontend/tiggle/src/pages/SettingPage/Item/Item.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/Item.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useState } from "react";
+import { UseFieldArrayRemove, UseFieldArrayUpdate } from "react-hook-form";
+
+import { AssetsInput } from "../AssetSettingPage";
+import ItemDisplay from "../ItemDisplay/ItemDisplay";
+import ItemEdit from "../ItemEdit/ItemEdit";
+
+type ItemStatus = "display" | "edit";
+
+interface ItemProps {
+  index: number;
+  value: {
+    sid: number;
+    label: string;
+  };
+  updateField: UseFieldArrayUpdate<AssetsInput>;
+  removeField: UseFieldArrayRemove;
+  defaultStatus?: ItemStatus;
+}
+
+const Item = ({
+  index,
+  value,
+  updateField,
+  removeField,
+  defaultStatus,
+}: ItemProps) => {
+  const [status, setStatus] = useState<ItemStatus>(defaultStatus || "display");
+
+  const edit = useCallback(() => setStatus("edit"), [status]);
+  const cancel = useCallback(() => setStatus("display"), [status]);
+  const save = (newValue: string) => {
+    if (value.sid === -1) {
+      // TODO: Asset Create API 연결
+      console.log("create asset");
+    } else {
+      // TODO: Asset Update API 연결
+      console.log("update asset");
+    }
+    updateField(index, { ...value, label: newValue });
+  };
+  const remove = () => {
+    // TODO: alert
+    removeField(index);
+    // TODO: Asset Delete API 연결
+  };
+
+  return status === "edit" ? (
+    <ItemEdit label={value.label} onCancel={cancel} onSave={save} />
+  ) : (
+    <ItemDisplay label={value.label} onEdit={edit} onRemove={remove} />
+  );
+};
+
+export default Item;

--- a/frontend/tiggle/src/pages/SettingPage/Item/ItemAdd.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/ItemAdd.tsx
@@ -1,6 +1,6 @@
 import { PlusCircle } from "react-feather";
 
-import { ItemAddStyle } from "../AssetSettingPageStyle";
+import { ItemAddStyle } from "./ItemStyle";
 
 interface ItemAddProps {
   onClick: () => void;

--- a/frontend/tiggle/src/pages/SettingPage/Item/ItemDisplay.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/ItemDisplay.tsx
@@ -1,18 +1,18 @@
-import { ItemStyle } from "../AssetSettingPageStyle";
+import { ItemStyle } from "./ItemStyle";
 
 interface ItemDisplayProps {
   label: string;
   onEdit: () => void;
-  onRemove: () => void;
+  onDelete: () => void;
 }
 
-const ItemDisplay = ({ label, onEdit, onRemove }: ItemDisplayProps) => {
+const ItemDisplay = ({ label, onEdit, onDelete }: ItemDisplayProps) => {
   return (
     <ItemStyle>
       <p className="label">{label}</p>
       <div className="controllers">
         <button onClick={onEdit}>수정</button>
-        <button onClick={onRemove}>삭제</button>
+        <button onClick={onDelete}>삭제</button>
       </div>
     </ItemStyle>
   );

--- a/frontend/tiggle/src/pages/SettingPage/Item/ItemEdit.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/ItemEdit.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useRef } from "react";
 
-import { ItemEditInputStyle, ItemStyle } from "../AssetSettingPageStyle";
+import { ItemEditInputStyle, ItemStyle } from "./ItemStyle";
 
 interface ItemEditProps {
   label: string;
-  onCancel: () => void;
   onSave: (newValue: string) => void;
+  onCancel: () => void;
 }
 
-const ItemEdit = ({ label, onCancel, onSave }: ItemEditProps) => {
+const ItemEdit = ({ label, onSave, onCancel }: ItemEditProps) => {
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const handleSave = () => {

--- a/frontend/tiggle/src/pages/SettingPage/Item/ItemStyle.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/ItemStyle.tsx
@@ -52,9 +52,3 @@ export const ItemAddStyle = styled.button`
     height: 14px;
   }
 `;
-
-export const ItemWrapperStyle = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-`;

--- a/frontend/tiggle/src/pages/SettingPage/Item/ItemStyle.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/Item/ItemStyle.tsx
@@ -24,6 +24,7 @@ export const ItemStyle = styled.li`
 
     display: flex;
     gap: 16px;
+    flex-shrink: 0;
   }
 `;
 

--- a/frontend/tiggle/src/pages/SettingPage/ItemAdd/ItemAdd.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/ItemAdd/ItemAdd.tsx
@@ -1,0 +1,18 @@
+import { PlusCircle } from "react-feather";
+
+import { ItemAddStyle } from "../AssetSettingPageStyle";
+
+interface ItemAddProps {
+  onClick: () => void;
+}
+
+const ItemAdd = ({ onClick }: ItemAddProps) => {
+  return (
+    <ItemAddStyle onClick={onClick}>
+      <PlusCircle />
+      <p>새 자산 추가하기</p>
+    </ItemAddStyle>
+  );
+};
+
+export default ItemAdd;

--- a/frontend/tiggle/src/pages/SettingPage/ItemDisplay/ItemDisplay.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/ItemDisplay/ItemDisplay.tsx
@@ -1,0 +1,21 @@
+import { ItemStyle } from "../AssetSettingPageStyle";
+
+interface ItemDisplayProps {
+  label: string;
+  onEdit: () => void;
+  onRemove: () => void;
+}
+
+const ItemDisplay = ({ label, onEdit, onRemove }: ItemDisplayProps) => {
+  return (
+    <ItemStyle>
+      <p className="label">{label}</p>
+      <div className="controllers">
+        <button onClick={onEdit}>수정</button>
+        <button onClick={onRemove}>삭제</button>
+      </div>
+    </ItemStyle>
+  );
+};
+
+export default ItemDisplay;

--- a/frontend/tiggle/src/pages/SettingPage/ItemEdit/ItemEdit.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/ItemEdit/ItemEdit.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from "react";
+
+import { ItemEditInputStyle, ItemStyle } from "../AssetSettingPageStyle";
+
+interface ItemEditProps {
+  label: string;
+  onCancel: () => void;
+  onSave: (newValue: string) => void;
+}
+
+const ItemEdit = ({ label, onCancel, onSave }: ItemEditProps) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleSave = () => {
+    const { value } = inputRef.current;
+    onSave(value);
+  };
+
+  useEffect(() => {
+    if (inputRef?.current) {
+      inputRef.current.focus();
+    }
+  }, [inputRef?.current]);
+
+  return (
+    <ItemStyle>
+      <ItemEditInputStyle
+        ref={inputRef}
+        className="label"
+        defaultValue={label}
+        placeholder="자산을 입력하세요"
+      />
+      <div className="controllers">
+        <button onClick={onCancel}>취소</button>
+        <button onClick={handleSave}>저장</button>
+      </div>
+    </ItemStyle>
+  );
+};
+
+export default ItemEdit;

--- a/frontend/tiggle/src/pages/SettingPage/OutcomeCategorySettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/OutcomeCategorySettingPage.tsx
@@ -70,7 +70,7 @@ const OutcomeCategorySettingPage = ({}: OutcomeCategorySettingPageProps) => {
 
   return (
     <MypageDetailPageStyle>
-      <p className="page-title">내 지출 카테고리 관리</p>
+      <p className="page-title">지출 카테고리 관리</p>
 
       {isLoading && <Loading />}
       {!isLoading && categoriesData && (

--- a/frontend/tiggle/src/pages/SettingPage/OutcomeCategorySettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/OutcomeCategorySettingPage.tsx
@@ -1,0 +1,86 @@
+import { useCallback } from "react";
+
+import { useMutation } from "@tanstack/react-query";
+
+import { Loading } from "@/components/atoms";
+import { CategoryApiControllerService } from "@/generated";
+import useMessage from "@/hooks/useMessage";
+import queryClient from "@/query/queryClient";
+import { categoryKeys } from "@/query/queryKeys";
+import { Tx } from "@/types";
+import withAuth, { AuthProps } from "@/utils/withAuth";
+
+import SettingForm from "./SettingForm/SettingForm";
+import { useCategoryQueryByTx } from "./query";
+import { MypageDetailPageStyle } from "../MyProfilePage/MyDetailPageCommonStyle";
+
+interface OutcomeCategorySettingPageProps extends AuthProps {}
+
+const OutcomeCategorySettingPage = ({}: OutcomeCategorySettingPageProps) => {
+  const messageApi = useMessage();
+  const { data: categoriesData, isLoading } = useCategoryQueryByTx(Tx.OUTCOME);
+  const { mutate: createMutate } = useMutation(async (name: string) =>
+    CategoryApiControllerService.createCategory({ name }),
+  );
+
+  const create = useCallback(
+    (
+      value: string,
+      callback?: (data: { id: number; name: string }) => void,
+    ) => {
+      createMutate(value, {
+        onSuccess: ({ id, name }) => {
+          callback?.({ id, name });
+          queryClient.invalidateQueries({
+            queryKey: categoryKeys.list({ type: Tx.OUTCOME }),
+          });
+          messageApi.open({ type: "success", content: "카테고리 생성 성공" });
+        },
+        onError: () => {
+          messageApi.open({ type: "error", content: "카테고리 생성 실패" });
+        },
+      });
+    },
+    [createMutate],
+  );
+
+  const update = useCallback(
+    (
+      sid: number,
+      newValue: string,
+      callback?: (data: { id: number; name: string }) => void,
+    ) => {
+      // TODO: API 연결
+      callback({ id: sid, name: newValue });
+      console.log(`OUTCOME CATEGORY PAGE - update api called`, sid, newValue);
+      messageApi.open({ type: "success", content: "카테고리 수정 성공" });
+    },
+    [],
+  );
+
+  const remove = useCallback(
+    (sid: number, callback?: (data: { id: number; name: string }) => void) => {
+      // TODO: API 연결
+      callback({ id: sid, name: "temp" });
+      console.log(`OUTCOME CATEGORY PAGE - delete api called`, sid);
+      messageApi.open({ type: "success", content: "카테고리 삭제 성공" });
+    },
+    [],
+  );
+
+  return (
+    <MypageDetailPageStyle>
+      <p className="page-title">내 지출 카테고리 관리</p>
+
+      {isLoading && <Loading />}
+      {!isLoading && categoriesData && (
+        <SettingForm
+          data={categoriesData.map(({ id, name }) => ({ sid: id, name }))}
+          requests={{ create, update, remove }}
+        />
+      )}
+    </MypageDetailPageStyle>
+  );
+};
+
+export default withAuth(OutcomeCategorySettingPage);

--- a/frontend/tiggle/src/pages/SettingPage/SettingForm/SettingForm.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/SettingForm/SettingForm.tsx
@@ -1,0 +1,34 @@
+import { SettingFormStyle } from "./SettingFormStyle";
+import useSettingForm, { SettingItem } from "./useSettingForm";
+import Item from "../Item/Item";
+import ItemAdd from "../Item/ItemAdd";
+
+export interface SettingFormProps {
+  data: Array<SettingItem>;
+  requests: {
+    create: (value: string) => void;
+    update: (sid: number, value: string) => void;
+    remove: (sid: number) => void;
+  };
+}
+
+const SettingForm = (props: SettingFormProps) => {
+  const { fields, appendItem, updateItem, removeItem } = useSettingForm(props);
+
+  return (
+    <SettingFormStyle>
+      {fields.map((field, index) => (
+        <Item
+          key={`setting-item-${index}`}
+          value={field}
+          save={(name: string) => updateItem(index, { ...field, name })}
+          deleteSelf={() => removeItem(index, field.sid)}
+          defaultStatus={field.sid === -1 ? "edit" : "display"}
+        />
+      ))}
+      <ItemAdd onClick={appendItem} />
+    </SettingFormStyle>
+  );
+};
+
+export default SettingForm;

--- a/frontend/tiggle/src/pages/SettingPage/SettingForm/SettingForm.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/SettingForm/SettingForm.tsx
@@ -1,16 +1,8 @@
 import { SettingFormStyle } from "./SettingFormStyle";
-import useSettingForm, { SettingItem } from "./useSettingForm";
+import { SettingFormProps } from "./types";
+import useSettingForm from "./useSettingForm";
 import Item from "../Item/Item";
 import ItemAdd from "../Item/ItemAdd";
-
-export interface SettingFormProps {
-  data: Array<SettingItem>;
-  requests: {
-    create: (value: string) => void;
-    update: (sid: number, value: string) => void;
-    remove: (sid: number) => void;
-  };
-}
 
 const SettingForm = (props: SettingFormProps) => {
   const { fields, appendItem, updateItem, removeItem } = useSettingForm(props);

--- a/frontend/tiggle/src/pages/SettingPage/SettingForm/SettingFormStyle.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/SettingForm/SettingFormStyle.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const SettingFormStyle = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;

--- a/frontend/tiggle/src/pages/SettingPage/SettingForm/types.ts
+++ b/frontend/tiggle/src/pages/SettingPage/SettingForm/types.ts
@@ -1,0 +1,31 @@
+export interface SettingItem {
+  /**
+   * server에서 부여되는 id
+   * React-hook-form에서 부여되는 client측 id와 구분하기 위해
+   * sid로 기재
+   */
+  sid: number;
+  name: string;
+}
+
+export type SettingInput<FieldName extends string> = {
+  [F in FieldName]: SettingItem[];
+};
+
+export type Data = {
+  id: number;
+  name: string;
+};
+
+export interface SettingFormProps {
+  data: Array<SettingItem>;
+  requests: {
+    create: (value: string, callback?: (data: Data) => void) => void;
+    update: (
+      sid: number,
+      value: string,
+      callback?: (data: Data) => void,
+    ) => void;
+    remove: (sid: number, callback?: (data: Data) => void) => void;
+  };
+}

--- a/frontend/tiggle/src/pages/SettingPage/SettingForm/useSettingForm.ts
+++ b/frontend/tiggle/src/pages/SettingPage/SettingForm/useSettingForm.ts
@@ -1,24 +1,11 @@
 import { useFieldArray, useForm } from "react-hook-form";
 
-import { SettingFormProps } from "./SettingForm";
-
-export interface SettingItem {
-  /**
-   * server에서 부여되는 id
-   * React-hook-form에서 부여되는 client측 id와 구분하기 위해
-   * sid로 기재
-   */
-  sid: number;
-  name: string;
-}
+import { SettingInput, SettingFormProps, SettingItem } from "./types";
 
 const fieldArrayName = "items";
-interface SettingInput {
-  [fieldArrayName]: SettingItem[];
-}
 
 const useSettingForm = ({ data, requests }: SettingFormProps) => {
-  const { control } = useForm<SettingInput>({
+  const { control } = useForm<SettingInput<typeof fieldArrayName>>({
     defaultValues: { [fieldArrayName]: data },
   });
 
@@ -32,18 +19,21 @@ const useSettingForm = ({ data, requests }: SettingFormProps) => {
   };
 
   const updateItem = (index: number, item: SettingItem) => {
-    update(index, item);
-
     if (item.sid === -1) {
-      requests.create(item.name);
+      requests.create(item.name, data => {
+        update(index, { sid: data.id, name: item.name });
+      });
     } else {
-      requests.update(item.sid, item.name);
+      requests.update(item.sid, item.name, () => {
+        update(index, item);
+      });
     }
   };
 
   const removeItem = (index: number, sid: number) => {
-    remove(index);
-    requests.remove(sid);
+    requests.remove(sid, () => {
+      remove(index);
+    });
   };
 
   return {

--- a/frontend/tiggle/src/pages/SettingPage/SettingForm/useSettingForm.ts
+++ b/frontend/tiggle/src/pages/SettingPage/SettingForm/useSettingForm.ts
@@ -1,0 +1,57 @@
+import { useFieldArray, useForm } from "react-hook-form";
+
+import { SettingFormProps } from "./SettingForm";
+
+export interface SettingItem {
+  /**
+   * server에서 부여되는 id
+   * React-hook-form에서 부여되는 client측 id와 구분하기 위해
+   * sid로 기재
+   */
+  sid: number;
+  name: string;
+}
+
+const fieldArrayName = "items";
+interface SettingInput {
+  [fieldArrayName]: SettingItem[];
+}
+
+const useSettingForm = ({ data, requests }: SettingFormProps) => {
+  const { control } = useForm<SettingInput>({
+    defaultValues: { [fieldArrayName]: data },
+  });
+
+  const { fields, append, update, remove } = useFieldArray({
+    control,
+    name: fieldArrayName,
+  });
+
+  const appendItem = () => {
+    append({ sid: -1, name: "" });
+  };
+
+  const updateItem = (index: number, item: SettingItem) => {
+    update(index, item);
+
+    if (item.sid === -1) {
+      requests.create(item.name);
+    } else {
+      requests.update(item.sid, item.name);
+    }
+  };
+
+  const removeItem = (index: number, sid: number) => {
+    remove(index);
+    requests.remove(sid);
+  };
+
+  return {
+    fields,
+    appendItem,
+    updateItem,
+    removeItem,
+  };
+};
+
+export default useSettingForm;

--- a/frontend/tiggle/src/pages/SettingPage/query.ts
+++ b/frontend/tiggle/src/pages/SettingPage/query.ts
@@ -1,10 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { AssetApiControllerService } from "@/generated";
-import { assetKeys } from "@/query/queryKeys";
+import {
+  AssetApiControllerService,
+  CategoryApiControllerService,
+} from "@/generated";
+import { assetKeys, categoryKeys } from "@/query/queryKeys";
+import { TxType } from "@/types";
 
 export const useAssetsQuery = () =>
   useQuery({
     queryKey: assetKeys.lists(),
     queryFn: async () => AssetApiControllerService.getAllAsset(),
+  });
+
+export const useCategoryQueryByTx = (type: Exclude<TxType, "REFUND">) =>
+  useQuery({
+    queryKey: categoryKeys.list({ type }),
+    queryFn: async () => CategoryApiControllerService.getCategory1(type),
   });

--- a/frontend/tiggle/src/pages/SettingPage/query.ts
+++ b/frontend/tiggle/src/pages/SettingPage/query.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { AssetApiControllerService } from "@/generated";
+import { assetKeys } from "@/query/queryKeys";
+
+export const useAssetsQuery = () =>
+  useQuery({
+    queryKey: assetKeys.lists(),
+    queryFn: async () => AssetApiControllerService.getAllAsset(),
+  });

--- a/frontend/tiggle/src/query/openapi-request.ts
+++ b/frontend/tiggle/src/query/openapi-request.ts
@@ -4,7 +4,7 @@ import { CancelablePromise, OpenAPIConfig } from "@/generated";
 import type { ApiRequestOptions } from "@/generated/core/ApiRequestOptions";
 import useCookie from "@/hooks/useCookie";
 
-const getAxiosInstance = () => {
+export const getAxiosInstance = () => {
   const { getCookie } = useCookie();
   const token = getCookie("Authorization");
 

--- a/frontend/tiggle/src/query/queryKeys.ts
+++ b/frontend/tiggle/src/query/queryKeys.ts
@@ -32,7 +32,7 @@ export const assetKeys = {
 };
 
 export const categoryKeys = {
-  key: "asset" as const,
+  key: "category" as const,
   lists: () => [categoryKeys.key, "list"] as const,
   list: (filter: Record<string, any>) =>
     [...categoryKeys.lists(), filter] as const,

--- a/frontend/tiggle/src/styles/config/GlobalStyle.tsx
+++ b/frontend/tiggle/src/styles/config/GlobalStyle.tsx
@@ -17,6 +17,11 @@ export const GlobalStyle = createGlobalStyle`
   * {
     box-sizing: border-box;
   }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
   
   br.break-m {
     ${({ theme }) => theme.mq.desktop} {

--- a/frontend/tiggle/src/templates/GeneralTemplate.tsx
+++ b/frontend/tiggle/src/templates/GeneralTemplate.tsx
@@ -1,30 +1,19 @@
-import { Outlet, useOutletContext } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
-import { message } from "antd";
-import { MessageInstance } from "antd/lib/message/interface";
 import styled from "styled-components";
 
 import MainHeader from "@/components/molecules/MainHeader/MainHeader";
 
-type ContextType = { messageApi: MessageInstance };
-
 export default function GeneralTemplate() {
-  const [messageApi, contextHolder] = message.useMessage();
-
   return (
-    <>
-      {contextHolder}
-      <GeneralTemplateStyle>
-        <MainHeader />
-        <div className="container">
-          <Outlet context={{ messageApi } satisfies ContextType} />
-        </div>
-      </GeneralTemplateStyle>
-    </>
+    <GeneralTemplateStyle>
+      <MainHeader />
+      <div className="container">
+        <Outlet />
+      </div>
+    </GeneralTemplateStyle>
   );
 }
-
-export const useMessage = () => useOutletContext<ContextType>();
 
 const GeneralTemplateStyle = styled.div`
   width: 100%;

--- a/frontend/tiggle/src/types/index.ts
+++ b/frontend/tiggle/src/types/index.ts
@@ -1,7 +1,7 @@
 export const Tx = {
+  INCOME: "INCOME",
   OUTCOME: "OUTCOME",
   REFUND: "REFUND",
-  INCOME: "INCOME",
 } as const;
 export type TxType = (typeof Tx)[keyof typeof Tx];
 

--- a/frontend/tiggle/src/utils/format.ts
+++ b/frontend/tiggle/src/utils/format.ts
@@ -1,0 +1,5 @@
+export const formatNumber = (num: number) => {
+  return Math.trunc(num)
+    .toString()
+    .replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};


### PR DESCRIPTION
### 작업 내용
- 내 정보 수정 페이지
  - FilterSelect와 BottomSheet, PopOver컴포넌트 작성
    - 추후에 @toss/use-overlay, framer 라이브러리 설치 후, 좀 더 읽기 편하게 리팩토링 할 계획입니다.
  - 페이지 view(index.tsx)와 controller(controller.ts) 분리
    - 페이지의 로직이 길어짐에 따라 페이지의 내용을 코드에서 한눈에 확인하기 어려워져, 로직부분과 화면 부분을 분리하여 작성했습니다.
- 내 거래 모아보기 페이지
  - react-hook-form의 Form Context를 활용
    - 따로 submit은 없지만 값변경에 따른 상태관리에 유용하여 react-hook-form을 이용했습니다!
  - 페이지 view(index.tsx)와 controller(controller.ts) 분리
- 자산/카테고리 관리 페이지
  - Alert 컴포넌트 작성
    - 삭제시 확인하는 절차를 아직 추가하지 않았습니다. 추후에 api 나온 후 작업하겠습니다
  - useMessage 수정
    - outlet context로 2 depth 이상 내려보낼 수 없어서, context api로 내려보내주도록 수정했습니다.