### PR TITLE
[FE] 프론트엔드 쪽 오류 수정

### DIFF
--- a/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.tsx
+++ b/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.tsx
@@ -1,5 +1,4 @@
 import { ButtonHTMLAttributes, ReactElement, cloneElement } from "react";
-import { Link } from "react-router-dom";
 
 import cn from "classnames";
 
@@ -34,10 +33,8 @@ export default function CTAButton({
       className={cn(className, size, color, variant, { fullWidth })}
       {...props}
     >
-      <Link to={"/create/income"}>
-        {icon && cloneElement(icon, { className: "cta-button-icon" })}
-        {children}
-      </Link>
+      {icon && cloneElement(icon, { className: "cta-button-icon" })}
+      {children}
     </CTAButtonStyle>
   );
 }

--- a/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.tsx
+++ b/frontend/tiggle/src/components/atoms/CTAButton/CTAButton.tsx
@@ -1,4 +1,5 @@
 import { ButtonHTMLAttributes, ReactElement, cloneElement } from "react";
+import { Link } from "react-router-dom";
 
 import cn from "classnames";
 
@@ -33,8 +34,10 @@ export default function CTAButton({
       className={cn(className, size, color, variant, { fullWidth })}
       {...props}
     >
-      {icon && cloneElement(icon, { className: "cta-button-icon" })}
-      {children}
+      <Link to={"/create/income"}>
+        {icon && cloneElement(icon, { className: "cta-button-icon" })}
+        {children}
+      </Link>
     </CTAButtonStyle>
   );
 }

--- a/frontend/tiggle/src/components/atoms/CTAButton/CTAButtonStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/CTAButton/CTAButtonStyle.tsx
@@ -5,6 +5,7 @@ import { expandTypography } from "@/styles/util";
 
 export const CTAButtonStyle = styled.button`
   width: fit-content;
+  white-space: nowrap;
   background-color: ${({ theme }) => theme.color.blue[600].value};
   color: ${({ theme }) => theme.color.white.value};
   border-radius: 50px;

--- a/frontend/tiggle/src/components/atoms/CTAButton/CTAButtonStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/CTAButton/CTAButtonStyle.tsx
@@ -10,10 +10,12 @@ export const CTAButtonStyle = styled.button`
   color: ${({ theme }) => theme.color.white.value};
   border-radius: 50px;
 
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
+  a {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+  }
 
   transition:
     background-color 0.1s ease,

--- a/frontend/tiggle/src/components/atoms/CTAButton/CTAButtonStyle.tsx
+++ b/frontend/tiggle/src/components/atoms/CTAButton/CTAButtonStyle.tsx
@@ -9,13 +9,10 @@ export const CTAButtonStyle = styled.button`
   background-color: ${({ theme }) => theme.color.blue[600].value};
   color: ${({ theme }) => theme.color.white.value};
   border-radius: 50px;
-
-  a {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 8px;
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
 
   transition:
     background-color 0.1s ease,

--- a/frontend/tiggle/src/pages/MainPage/Banner/Banner.tsx
+++ b/frontend/tiggle/src/pages/MainPage/Banner/Banner.tsx
@@ -14,6 +14,7 @@ export default function Banner() {
           icon={<Edit3 />}
           children={"기록하기"}
           className="banner-button"
+          link="/create/income"
         />
       </div>
     </BannerStyle>

--- a/frontend/tiggle/src/pages/MainPage/Banner/Banner.tsx
+++ b/frontend/tiggle/src/pages/MainPage/Banner/Banner.tsx
@@ -1,4 +1,5 @@
 import { Edit3 } from "react-feather";
+import { Link } from "react-router-dom";
 
 import CTAButton from "@/components/atoms/CTAButton/CTAButton";
 import { BannerStyle } from "@/pages/MainPage/Banner/BannerStyle";
@@ -9,13 +10,14 @@ export default function Banner() {
       <div className="banner-wrap">
         <p className="banner-title">함께 해서 즐거운 절약 생활 🎣</p>
         <p className="banner-sub-title">나의 지출/수입을 공유해보세요</p>
-        <CTAButton
-          size={"lg"}
-          icon={<Edit3 />}
-          children={"기록하기"}
-          className="banner-button"
-          link="/create/income"
-        />
+        <Link to="/create/income">
+          <CTAButton
+            size={"lg"}
+            icon={<Edit3 />}
+            children={"기록하기"}
+            className="banner-button"
+          />
+        </Link>
       </div>
     </BannerStyle>
   );

--- a/frontend/tiggle/src/pages/MainPage/Banner/BannerStyle.tsx
+++ b/frontend/tiggle/src/pages/MainPage/Banner/BannerStyle.tsx
@@ -14,6 +14,10 @@ export const BannerStyle = styled.div`
     align-items: center;
     padding: 60px 24px;
 
+    a {
+      margin-top: 24px;
+    }
+
     ${({ theme }) => theme.mq.desktop} {
       width: 768px;
       padding: 80px 24px;
@@ -37,10 +41,6 @@ export const BannerStyle = styled.div`
       ${({ theme }) => theme.mq.desktop} {
         ${({ theme }) => expandTypography(theme.typography.body.large.medium)};
       }
-    }
-
-    > .banner-button {
-      margin-top: 24px;
     }
   }
 `;

--- a/frontend/tiggle/src/pages/MyProfilePage/controller.ts
+++ b/frontend/tiggle/src/pages/MyProfilePage/controller.ts
@@ -45,7 +45,7 @@ export const useProfilePage = () => {
     defaultValues: {
       nickname: profileData.nickname,
       email: profileData.email,
-      birth: dayjs(profileData.birth),
+      birth: profileData.birth ? dayjs(profileData.birth) : null,
     },
   });
   const profileUrlRegister = register("profileUrl");

--- a/frontend/tiggle/src/pages/MyProfilePage/types.ts
+++ b/frontend/tiggle/src/pages/MyProfilePage/types.ts
@@ -4,7 +4,7 @@ import { MemberDto } from "@/generated";
 
 export type ProfileInputs = Partial<
   Omit<MemberDto, "id" | "birth" | "profileUrl"> & {
-    birth: Dayjs;
+    birth: Dayjs | null;
     profileUrl: File[];
   }
 >;

--- a/frontend/tiggle/src/pages/SettingPage/IncomeCategorySettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/IncomeCategorySettingPage.tsx
@@ -22,7 +22,11 @@ const IncomeCategorySettingPage = ({}: IncomeCategorySettingPageProps) => {
     queryFn: async () => CategoryApiControllerService.getCategory1(Tx.INCOME),
   });
   const { mutate: createMutate } = useMutation(async (name: string) =>
-    CategoryApiControllerService.createCategory({ name }),
+    CategoryApiControllerService.createCategory({
+      name,
+      type: Tx.INCOME,
+      defaults: true,
+    }),
   );
 
   const create = useCallback(

--- a/frontend/tiggle/src/pages/SettingPage/OutcomeCategorySettingPage.tsx
+++ b/frontend/tiggle/src/pages/SettingPage/OutcomeCategorySettingPage.tsx
@@ -21,8 +21,16 @@ const OutcomeCategorySettingPage = ({}: OutcomeCategorySettingPageProps) => {
     queryKey: categoryKeys.list({ type: Tx.OUTCOME }),
     queryFn: async () => CategoryApiControllerService.getCategory1(Tx.OUTCOME),
   });
+  // const { mutate: createMutate } = useMutation(async (name: string) =>
+  //   CategoryApiControllerService.createCategory({ name }),
+  // );
+
   const { mutate: createMutate } = useMutation(async (name: string) =>
-    CategoryApiControllerService.createCategory({ name }),
+    CategoryApiControllerService.createCategory({
+      name,
+      type: Tx.OUTCOME,
+      defaults: true,
+    }),
   );
 
   const create = useCallback(

--- a/frontend/tiggle/src/styles/config/GlobalStyle.tsx
+++ b/frontend/tiggle/src/styles/config/GlobalStyle.tsx
@@ -9,6 +9,7 @@ export const GlobalStyle = createGlobalStyle`
     font-family: 'Pretendard Variable', Pretendard, system-ui, sans-serif;
     
     margin: 0;
+    min-width: 375px;
     width: 100vw;
     height: 100vh;
     background-color: ${({ theme }) => theme.color.bluishGray[50].value};


### PR DESCRIPTION
## 작업 내용

### CSS
- GlovalStyle 컴포넌트에 `min-width : 375px;`를 추가하여 `375px` 이하로 줄이면 고정이 되도록 수정해두었습니다.
- CRA 버튼 줄바꿈 방지를 위해 `white-space: nowrap;` 을 추가했습니다. 

### 기록하기 버튼
- 기록하기 버튼에 수익 기록하기 페이지를 연결해두었습니다.
- 기록하기(CRA) 버튼의 경우 메인 페이지 외 다른 페이지에서도 쓰이고 있어 메인 페이지에서만 Link 컴포넌트로 이동할 수 있도록 해두었습니다. (간단한 CSS 수정도 같이 이루어졌습니다.)

### 카테고리 & 자산 생성 api
- 카테고리 (지출 / 수입) 생성 시 보내는 data를 수정해두었습니다.

### 생년월일 Date 문제
- MyProfilePage의 controller 함수에서 사용하고 있는 `profileData.birth` 부분이 `null` 로 들어오는 경우 `placeholder`가 보이게끔 공란으로 처리해 프로필 수정 페이지 진입시 `Invalid Date`가 뜨는 문제를 처리했습니다. 
- `ProfileInputs` type 부분의 `birth`가 `null` 타입도 받을 수 있도록 수정했습니다.

---

프로필 수정 api 제외한 부분만 우선 작업 완료하여 PR 올립니다. 🧚‍♀️