### PR TITLE
[BE] 프로필 수정 API 버그 수정

### DIFF
--- a/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/domain/member/api/MemberApiController.kt
+++ b/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/domain/member/api/MemberApiController.kt
@@ -2,6 +2,7 @@ package com.side.tiggle.domain.member.api
 
 import com.side.tiggle.domain.member.dto.controller.MemberRequestDto
 import com.side.tiggle.domain.member.dto.controller.MemberResponseDto
+import com.side.tiggle.domain.member.dto.controller.MemberUpdateReqDto
 import com.side.tiggle.domain.member.dto.service.MemberDto
 import com.side.tiggle.domain.member.service.MemberService
 import com.side.tiggle.global.common.constants.HttpHeaders
@@ -68,11 +69,11 @@ class MemberApiController(
     fun updateMe(
         @Parameter(hidden = true)
         @RequestHeader(name = HttpHeaders.MEMBER_ID) memberId: Long,
-        @RequestPart memberRequestDto: MemberRequestDto,
-        @RequestPart("multipartFile") file: MultipartFile?
+        @RequestPart(required = false) memberRequestDto: MemberUpdateReqDto?,
+        @RequestPart("multipartFile", required = false) file: MultipartFile?
     ): ResponseEntity<MemberResponseDto> {
         return ResponseEntity(
-            MemberDto.fromEntityToMemberResponseDto(memberService.updateMember(memberId, MemberRequestDto.fromMemberRequestDtoToMemberDto(memberRequestDto), file)),
+            MemberDto.fromEntityToMemberResponseDto(memberService.updateMember(memberId, memberRequestDto, file)),
             HttpStatus.OK
         )
     }

--- a/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/domain/member/dto/controller/MemberUpdateReqDto.kt
+++ b/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/domain/member/dto/controller/MemberUpdateReqDto.kt
@@ -1,0 +1,9 @@
+package com.side.tiggle.domain.member.dto.controller
+
+import com.side.tiggle.domain.member.dto.service.MemberDto
+import java.time.LocalDate
+
+data class MemberUpdateReqDto(
+    val nickname: String?,
+    val birth: LocalDate?
+)

--- a/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/domain/member/service/MemberService.kt
+++ b/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/domain/member/service/MemberService.kt
@@ -1,6 +1,7 @@
 package com.side.tiggle.domain.member.service
 
 import com.side.tiggle.domain.member.dto.controller.MemberResponseDto
+import com.side.tiggle.domain.member.dto.controller.MemberUpdateReqDto
 import com.side.tiggle.domain.member.dto.service.MemberDto
 import com.side.tiggle.domain.member.model.Member
 import com.side.tiggle.domain.member.repository.MemberRepository
@@ -36,17 +37,29 @@ class MemberService(
         return memberRepository.findAll()
     }
 
-    fun updateMember(memberId: Long, memberDto: MemberDto, file: MultipartFile?): Member {
+    fun updateMember(memberId: Long, memberUpdateReqDto: MemberUpdateReqDto?, file: MultipartFile?): Member {
+        var isModified = false
         val member: Member = memberRepository.findById(memberId)
             .orElseThrow { NotFoundException() }
         if (file != null && !file.isEmpty) {
             member.profileUrl = uploadProfile(memberId, file)
+            isModified = true
         }
 
-        member.nickname = memberDto.nickname
-        member.birth = memberDto.birth
+        if (memberUpdateReqDto?.nickname != null) {
+            member.nickname = memberUpdateReqDto.nickname
+            isModified = true
+        }
 
-        return memberRepository.save(member)
+        if (memberUpdateReqDto?.birth != null) {
+            member.birth = memberUpdateReqDto.birth
+            isModified = true
+        }
+
+        if (isModified) {
+            memberRepository.save(member)
+        }
+        return member
     }
 
     fun uploadProfile(memberId: Long, file: MultipartFile): String {


### PR DESCRIPTION
* 프로필 수정 시 email, imageUrl 이 파라미터로 들어가 있는 부분을 수정하기 위해 memberUpdateReqDto 를 따로 생성
* 모든 필드를 optional 로 설정
* 실제 수정이 발생했을 때에만 save를 치기 위해 플래그 로직 추가
* 이미지 업로드 및 노출은 테스트를 해봤는데 역시 문제가 있더라고요... 생각해본 방법이 있는데 회의 때 공유드리겠습니다. (Synology를 이미지 서버로 사용하는 방법)