### PR TITLE
[BE] 이미지 서버 생성

### DIFF
--- a/backend/image-server/.env.dev
+++ b/backend/image-server/.env.dev
@@ -1,0 +1,2 @@
+PORT=8000
+FILE_DIRECTORY=C:\Users\cs240\IdeaProjects\Tiggle\backend\image-server\images

--- a/backend/image-server/.env.prod
+++ b/backend/image-server/.env.prod
@@ -1,0 +1,2 @@
+PORT=8000
+FILE_DIRECTORY=/app/images

--- a/backend/image-server/Dockerfile
+++ b/backend/image-server/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:12
+
+WORKDIR /app
+COPY . .
+
+EXPOSE 8000
+RUN npm install
+
+CMD [ "npm", "start" ]

--- a/backend/image-server/index.js
+++ b/backend/image-server/index.js
@@ -1,0 +1,48 @@
+import multer from 'multer';
+import express from 'express';
+import dotenv from 'dotenv';
+import { v4 as uuid } from 'uuid';
+import * as path from "node:path";
+
+dotenv.config()
+switch (process.env.NODE_ENV) {
+    case 'dev': dotenv.config({ path: ".env.dev" }); break;
+    default: dotenv.config({ path: ".env.prod" }); break;
+}
+
+let app = express()
+let port = process.env.PORT
+
+let savePath = process.env.FILE_DIRECTORY
+console.log(savePath)
+
+let storage = multer.diskStorage({
+    // 저장 경로
+    destination: function (req, file, cb) {
+        cb(null, savePath)
+    },
+    // 저장 파일 명
+    filename: function (req, file, cb) {
+        let ext = path.extname(file.originalname)
+        cb(null, `${uuid()}${ext}`)
+    },
+    limits: {
+        fileSize: 1024 * 1024 * 32 // 32 mb
+    }
+})
+let upload = multer({storage: storage})
+
+app.post("/upload", upload.single("image"),
+    function (req, res) {
+        console.log(req.file);
+        return res.status(200).json({})
+    }
+)
+
+app.get("/image/:imageName", function (req, res) {
+    res.sendFile(path.join(savePath, req.params.imageName))
+})
+
+app.listen(port, ()=>{
+    console.log(`Server started on port ${port}`)
+})

--- a/backend/image-server/package.json
+++ b/backend/image-server/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "image-server",
+  "version": "1.0.0",
+  "description": "tiggle의 이미지 서버 입니다",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "dev": "cross-env NODE_ENV=dev node index.js",
+    "start": "cross-env NODE_ENV=prod node index.js"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cross-env": "^7.0.3",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "multer": "^1.4.5-lts.1",
+    "uuid": "^9.0.1"
+  }
+}

--- a/docker-compose.kafka.yml
+++ b/docker-compose.kafka.yml
@@ -59,6 +59,16 @@ services:
       - KAFKA_CLUSTERS_0_ZOOKEEPER=zookeeper:2181
     networks:
       - springboot-mysql-net
+  image-server:
+    build:
+      context: ./backend/image-server
+      dockerfile: Dockerfile
+    restart: always
+    ports:
+      - "8000:8000"
+    container_name: image_server
+    volumes:
+      - "/var/services/homes/dev/images:/app/images"
 networks:
   springboot-mysql-net:
     driver: bridge


### PR DESCRIPTION
* nodejs 를 사용한 이미지 서버 입니다.
* 기본적인 업로드와 이미지 조회 API 구현해뒀고, 추후에 core 쪽의 upload와 image url 로직은 해당 서버 구현에 맞춰 수정하면 좋을 것 같습니다.
* local test 방법
1. .env.dev 에서 이미지 저장 경로를 자신의 로컬에 맞게 변경
2. `npm run dev`
3. postman 을 사용하여 API 테스트

![image](https://github.com/kdh-92/Tiggle/assets/43139156/b0cdfeee-ac03-4a9f-a717-0b3691d623a9)
![image](https://github.com/kdh-92/Tiggle/assets/43139156/35e0e510-2401-4968-b16a-5fc767ffa010)
