### PR TITLE
OAuth2 인증 호환성 문제 해결

### DIFF
--- a/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/global/config/SecurityConfig.kt
+++ b/backend/tiggle-root/tiggle/src/main/kotlin/com/side/tiggle/global/config/SecurityConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
@@ -27,8 +28,9 @@ class SecurityConfig(
             .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .addFilterBefore(JwtRequestFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter::class.java)
-            .authorizeHttpRequests()
-            .requestMatchers("/**").permitAll()
+            .authorizeHttpRequests {
+                it.requestMatchers(AntPathRequestMatcher("/**")).permitAll()
+            }
 
         http.oauth2Login()
             .successHandler(successHandler)

--- a/backend/tiggle-root/tiggle/src/main/resources/application.yml.example
+++ b/backend/tiggle-root/tiggle/src/main/resources/application.yml.example
@@ -31,7 +31,7 @@ spring:
           naver:
             client-id: ${OAUTH2_NAVER_CLIENT_ID}
             client-secret: ${OAUTH2_NAVER_CLIENT_SECRET}
-            client-authentication-method: post
+            client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
             scope:
@@ -42,7 +42,7 @@ spring:
           kakao:
             client-id: ${OAUTH2_KAKAO_CLIENT_ID}
             client-secret: ${OAUTH2_KAKAO_CLIENT_SECRET}
-            client-authentication-method: post
+            client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             redirect-uri: "{baseUrl}/{action}/oauth2/code/{registrationId}"
             scope:


### PR DESCRIPTION
## 📌 PR 유형 (해당하는 항목에 모두 체크해주세요)
- [ ] Feat: 새로운 기능 추가
- [x] Fix: 버그 수정
- [ ] Docs: 문서 수정
- [ ] Style: 코드 포맷팅, 세미콜론 누락, 코드 변경이 없는 경우
- [x] Refactor: 코드 리팩토링 (기능 변경 없이 구조 개선)
- [ ] Test: 테스트 코드 추가 및 기존 테스트 리팩토링
- [ ] Chore: 빌드 설정, 패키지 매니저 설정 등 기타 변경
- [ ] Github: PR 템플릿, 이슈 템플릿, Github Actions 설정 등
- [ ] Conflict: 머지 시 충돌 해결

## ✨ 변경 사항

### Spring Security 6.0 호환성 문제 해결
- **OAuth2 클라이언트 인증 방식 수정**: `client-authentication-method: post` → `client_secret_post`로 변경
- **MvcRequestMatcher 경로 매칭 문제 해결**: `AntPathRequestMatcher` 명시적 사용으로 서블릿 경로 설정 문제 해결

## 🔍 리뷰어에게

Spring Boot 3.0.13 업그레이드 과정에서 Spring Security가 자동으로 6.0으로 업그레이드되면서 발생한 호환성 문제들을 해결했습니다.

**주요 해결 사항:**
1. **OAuth2 인증 오류**: 카카오/네이버 로그인 시 `IllegalArgumentException` 발생 → RFC 6749 표준 방식으로 수정
    application.yml에서 post를 표준방식으로 수정
    
2. **경로 매칭 오류**: `MvcRequestMatcher` 서블릿 경로 미설정 문제 → `AntPathRequestMatcher` 명시 사용
    SecurityConfig 경로수정

변경사항은 로컬 테스트 완료

## ✅ PR 체크리스트
- [x] 커밋 메시지를 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항을 로컬에서 테스트했습니다.
- [x] 관련 라벨을 선택했습니다.

## 🔗 관련 이슈
`#155`