### PR TITLE
fix(fe): restore TypeTag.tsx and fix lint errors blocking CI

### DIFF
--- a/docs/sessions/2026-04-12_1_plan.md
+++ b/docs/sessions/2026-04-12_1_plan.md
@@ -1,0 +1,45 @@
+# CI/CD 안정화 - tiggle, calynda, AIVA-SaaS
+> 날짜: 2026-04-12 | 회차: 1 | 상태: 진행중
+
+## 요청 내용
+tiggle, calynda, aiav-bb(AIVA-SaaS) 세 프로젝트의 GitHub Actions CI가 자주 실패하는 원인 분석 및 안정화
+
+## 영향 범위 분석
+
+### Tiggle (72% CI 실패율)
+- **근본 원인**: `TypeTag.tsx` 파일 누락 → 모든 FE 빌드 실패
+- **부가 원인**: `DetailPage/index.tsx` prettier 포맷팅 오류, `NotFoundPage.tsx` import 순서 오류
+- 변경 파일:
+  - `frontend/tiggle/src/components/atoms/TypeTag/TypeTag.tsx` (복구)
+  - `frontend/tiggle/src/pages/DetailPage/index.tsx` (prettier 수정)
+  - `frontend/tiggle/src/pages/NotFoundPage.tsx` (import order 수정)
+
+### Calynda (CI 통과 중, 개선 필요)
+- **이슈**: FE(Flutter) 테스트가 CI에 없음. 15개 테스트 파일 존재하지만 미실행
+- 변경 파일:
+  - `be/.github/workflows/ci.yml` (frontend-test job 추가)
+  - `be/.github/workflows/deploy-nas.yml` (test-frontend gate job 추가)
+
+### AIVA-SaaS (현재 안정 - 최근 5회 연속 성공)
+- 과거 이슈: Flyway 마이그레이션 충돌, BLoC 상태관리 버그 (해결됨)
+- 현재 안정 상태 → 즉시 수정 불필요
+
+## 작업 계획
+| # | 작업 | 프로젝트 | 파일 | 난이도 |
+|---|------|---------|------|--------|
+| 1 | TypeTag.tsx 복구 | Tiggle | atoms/TypeTag/TypeTag.tsx | S |
+| 2 | prettier/import 오류 수정 | Tiggle | DetailPage, NotFoundPage | S |
+| 3 | FE 빌드 + BE 테스트 로컬 검증 | Tiggle | - | S |
+| 4 | Flutter 테스트 CI 추가 | Calynda | ci.yml, deploy-nas.yml | M |
+| 5 | AIVA-SaaS 현황 분석 | AIVA-SaaS | - | S |
+
+## 성능 설계
+- CI 실행 시간 영향: Flutter 테스트 추가로 Calynda CI ~2-3분 증가 (허용 범위)
+- Calynda deploy에서 test-frontend이 test-backend과 병렬 실행되므로 총 시간 증가 최소화
+
+## 검증 계획
+- [x] Tiggle BE 테스트 통과 (`./gradlew :tiggle:test`)
+- [x] Tiggle FE 빌드 통과 (`npm run build`)
+- [x] Calynda CI YAML 문법 검증
+- [ ] Tiggle 커밋 후 CI 통과 확인 (GitHub Actions)
+- [ ] Calynda 커밋 후 CI 통과 확인 (GitHub Actions)

--- a/frontend/tiggle/src/components/atoms/TypeTag/TypeTag.tsx
+++ b/frontend/tiggle/src/components/atoms/TypeTag/TypeTag.tsx
@@ -1,0 +1,33 @@
+import { HTMLAttributes } from "react";
+
+import cn from "classnames";
+
+import { TypeTagStyle } from "@/components/atoms/TypeTag/TypeTagStyle";
+import { Tx, TxType } from "@/types";
+
+interface TypeTagProps extends HTMLAttributes<HTMLDivElement> {
+  size: "md" | "lg";
+  txType: TxType;
+}
+
+export default function TypeTag({
+  size,
+  txType,
+  className,
+  ...props
+}: TypeTagProps) {
+  return (
+    <TypeTagStyle
+      className={cn("type-tag", txType, className, size)}
+      {...props}
+    >
+      <p className="label">
+        {txType === Tx.OUTCOME
+          ? "지출"
+          : txType === Tx.REFUND
+            ? "환불"
+            : "수익"}
+      </p>
+    </TypeTagStyle>
+  );
+}

--- a/frontend/tiggle/src/pages/DetailPage/index.tsx
+++ b/frontend/tiggle/src/pages/DetailPage/index.tsx
@@ -55,7 +55,14 @@ const DetailPage = () => {
   if (!transactionData?.data) {
     return (
       <DetailPageStyle className="page-container">
-        <div style={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "50vh" }}>
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            minHeight: "50vh",
+          }}
+        >
           불러오는 중...
         </div>
       </DetailPageStyle>

--- a/frontend/tiggle/src/pages/NotFoundPage.tsx
+++ b/frontend/tiggle/src/pages/NotFoundPage.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+
 import styled from "styled-components";
 
 const NotFoundPageStyle = styled.div`


### PR DESCRIPTION
## Summary
- **TypeTag.tsx 복구**: `86761c1` 커밋에서 실수로 삭제된 컴포넌트 복원 (FE 빌드 실패의 근본 원인)
- **DetailPage prettier 수정**: 인라인 style 객체 포맷팅 오류 수정
- **NotFoundPage import 순서 수정**: import 그룹 간 빈 줄 추가

## 검증
- [x] BE 테스트 통과
- [x] FE 빌드 통과
- [x] FE Lint 통과

## Test plan
- [ ] CI에서 backend-test, frontend-test 모두 통과 확인
- [ ] 머지 후 Deploy workflow 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **New Features**
  * TypeTag 컴포넌트가 추가되어 거래 유형(지출/환불/수익)을 명확하게 표시할 수 있습니다.

* **Style**
  * 상세 페이지의 로딩 상태 스타일 코드 개선

* **Documentation**
  * CI 안정화 계획 문서가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->